### PR TITLE
Updated how API is called so it can support both client-side and server-side calls in a secure way

### DIFF
--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -2,6 +2,9 @@ import { DecisionGraphType } from "@gorules/jdm-editor/dist/components/decision-
 import axios from "axios";
 import { RuleInfo } from "../types/ruleInfo";
 
+// For server side calls, need full URL, otherwise can just use /api
+const API_URI = typeof window === "undefined" ? process.env.NEXT_PUBLIC_API_URL : "/api";
+
 const GO_RULES_ROOT_PROJECT_URL = `https://sdpr.gorules.io/api/projects/${process.env.NEXT_PUBLIC_GO_RULES_PROJECT_ID}`;
 
 const goRulesAxiosInstance = axios.create({
@@ -60,7 +63,7 @@ export const postDecision = async (jsonFile: string, decisionGraph: DecisionGrap
  */
 export const getSubmissionsFromCHEFS = async (formId: string) => {
   try {
-    const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/submissions/list/${formId}`);
+    const { data } = await axios.get(`${API_URI}/submissions/list/${formId}`);
     return data;
   } catch (error) {
     console.error(`Error fetching submissions: ${error}`);
@@ -75,7 +78,7 @@ export const getSubmissionsFromCHEFS = async (formId: string) => {
  */
 export const getSubmissionFromCHEFSById = async (formId: string, id: string) => {
   try {
-    const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/submissions/${formId}/${id}`);
+    const { data } = await axios.get(`${API_URI}/submissions/${formId}/${id}`);
     return data;
   } catch (error) {
     console.error(`Error fetching submissions: ${error}`);
@@ -91,7 +94,7 @@ export const getSubmissionFromCHEFSById = async (formId: string, id: string) => 
  */
 export const getRuleDataById = async (ruleId: string): Promise<RuleInfo> => {
   try {
-    const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/ruleData/${ruleId}`);
+    const { data } = await axios.get(`${API_URI}/ruleData/${ruleId}`);
     return data;
   } catch (error) {
     console.error(`Error getting rule data: ${error}`);
@@ -106,7 +109,7 @@ export const getRuleDataById = async (ruleId: string): Promise<RuleInfo> => {
  */
 export const getAllRuleData = async (): Promise<RuleInfo[]> => {
   try {
-    const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/ruleData/list`);
+    const { data } = await axios.get(`${API_URI}/ruleData/list`);
     return data;
   } catch (error) {
     console.error(`Error fetching rule data: ${error}`);
@@ -122,7 +125,7 @@ export const getAllRuleData = async (): Promise<RuleInfo[]> => {
  */
 export const postRuleData = async (newRuleData: unknown) => {
   try {
-    const { data } = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/ruleData`, newRuleData);
+    const { data } = await axios.post(`${API_URI}/ruleData`, newRuleData);
     return data;
   } catch (error) {
     console.error(`Error posting rule data: ${error}`);
@@ -139,7 +142,7 @@ export const postRuleData = async (newRuleData: unknown) => {
  */
 export const updateRuleData = async (ruleId: string, updatedRuleData: unknown) => {
   try {
-    const { data } = await axios.put(`${process.env.NEXT_PUBLIC_API_URL}/ruleData/${ruleId}`, updatedRuleData);
+    const { data } = await axios.put(`${API_URI}/ruleData/${ruleId}`, updatedRuleData);
     return data;
   } catch (error) {
     console.error(`Error updating rule: ${error}`);
@@ -155,7 +158,7 @@ export const updateRuleData = async (ruleId: string, updatedRuleData: unknown) =
  */
 export const deleteRuleData = async (ruleId: string) => {
   try {
-    const { data } = await axios.delete(`${process.env.NEXT_PUBLIC_API_URL}/ruleData/${ruleId}`);
+    const { data } = await axios.delete(`${API_URI}/ruleData/${ruleId}`);
     return data;
   } catch (error) {
     console.error(`Error deleting rule: ${error}`);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,20 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+
+const nextConfig = {
+  async rewrites() {
+    // Proxy API requests to the backend at server when in development
+    // In dev/production, this is setup on OpenShift
+    if (process.env.NODE_ENV === "development") {
+      return [
+        {
+          source: "/api/:path*",
+          destination: `${process.env.NEXT_PUBLIC_API_URL}/:path*`,
+        },
+      ];
+    } else {
+      return [];
+    }
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
This removes the need to have an exposed API endpoint. 

The issue was that Nextjs can make both client-side and server-side requests. The server side requests couldn't make use of the Keycloak credentials so they required an open API endpoint.

With this change the server-side requests can use the OpenShift service directly like `http://brms-api:3000/api` and the client side can use just `/api` with its Keycloak credentials.

I also update the Nextjs config to be inline with our OpenShift deployment that has the API accessible to the frontend at `api`

Note: I skipped the usual process and already merged this into dev because I wasn't sure if it would work or not.