### PR TITLE
Simulate on edit

### DIFF
--- a/app/components/RulesDecisionGraph/RulesDecisionGraph.tsx
+++ b/app/components/RulesDecisionGraph/RulesDecisionGraph.tsx
@@ -18,7 +18,8 @@ import { getScenariosByFilename } from "../../utils/api";
 
 interface RulesViewerProps {
   jsonFilename: string;
-  graphJSON: DecisionGraphType;
+  ruleContent: DecisionGraphType;
+  setRuleContent: (updateGraph: DecisionGraphType) => void;
   contextToSimulate?: Record<string, any> | null;
   setContextToSimulate: (results: Record<string, any>) => void;
   simulation?: Simulation;
@@ -28,20 +29,16 @@ interface RulesViewerProps {
 
 export default function RulesDecisionGraph({
   jsonFilename,
-  graphJSON,
+  ruleContent,
+  setRuleContent,
   contextToSimulate,
   setContextToSimulate,
   simulation,
   runSimulation,
   isEditable = true,
 }: RulesViewerProps) {
-  const [graphValue, setGraphValue] = useState<any>(graphJSON);
   const decisionGraphRef: any = useRef<DecisionGraphRef>();
   const [reactFlowRef, setReactFlowRef] = useState<ReactFlowInstance>();
-
-  useEffect(() => {
-    setGraphValue(graphJSON);
-  }, [graphJSON]);
 
   useEffect(() => {
     // Ensure graph is in view
@@ -56,7 +53,7 @@ export default function RulesDecisionGraph({
     };
     // Fit to view
     fitGraphToView();
-  }, [graphValue, reactFlowRef]);
+  }, [ruleContent, reactFlowRef]);
 
   // Can set additional react flow options here if we need to change how graph looks when it's loaded in
   const reactFlowInit = (reactFlow: ReactFlowInstance) => {
@@ -96,7 +93,7 @@ export default function RulesDecisionGraph({
         })),
       };
       const updatedJSON = {
-        ...graphValue,
+        ...ruleContent,
         ...scenarioObject,
       };
       return downloadJSON(updatedJSON, jsonFilename);
@@ -170,14 +167,14 @@ export default function RulesDecisionGraph({
     <JdmConfigProvider>
       <DecisionGraph
         ref={decisionGraphRef}
-        value={graphValue}
+        value={ruleContent}
         defaultOpenMenu={false}
         simulate={simulation}
         configurable
         onReactFlowInit={reactFlowInit}
         panels={panels}
         components={additionalComponents}
-        onChange={(updatedGraphValue) => setGraphValue(updatedGraphValue)}
+        onChange={(updatedGraphValue) => setRuleContent(updatedGraphValue)}
         disabled={!isEditable}
       />
     </JdmConfigProvider>

--- a/app/components/RulesDecisionGraph/RulesDecisionGraph.tsx
+++ b/app/components/RulesDecisionGraph/RulesDecisionGraph.tsx
@@ -14,6 +14,7 @@ import { ApartmentOutlined, PlayCircleOutlined } from "@ant-design/icons";
 import { Scenario, Variable } from "@/app/types/scenario";
 import LinkRuleComponent from "./LinkRuleComponent";
 import SimulatorPanel from "./SimulatorPanel";
+import { downloadFileBlob } from "@/app/utils/utils";
 import { getScenariosByFilename } from "../../utils/api";
 
 interface RulesViewerProps {
@@ -61,19 +62,7 @@ export default function RulesDecisionGraph({
   };
 
   const downloadJSON = (jsonData: any, filename: string) => {
-    const jsonString = JSON.stringify(jsonData, null, 2);
-    const blob = new Blob([jsonString], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = filename;
-    document.body.appendChild(link);
-    link.click();
-
-    // Clean up and remove the link
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    downloadFileBlob(JSON.stringify(jsonData, null, 2), "application/json", filename);
   };
 
   const handleScenarioInsertion = async () => {
@@ -125,7 +114,7 @@ export default function RulesDecisionGraph({
       document.removeEventListener("click", clickHandler);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [ruleContent]);
 
   // This is to add the decision node - note that this may be added to the DecisionGraph library
   const additionalComponents: NodeSpecification[] = useMemo(

--- a/app/components/ScenarioGenerator/ScenarioGenerator.tsx
+++ b/app/components/ScenarioGenerator/ScenarioGenerator.tsx
@@ -3,13 +3,13 @@ import { Flex, Button, Input } from "antd";
 import InputOutputTable from "../InputOutputTable";
 import { Scenario } from "@/app/types/scenario";
 import { createScenario } from "@/app/utils/api";
-import ScenarioFormatter from "../ScenarioFormatter";
 import { RuleMap } from "@/app/types/rulemap";
+import ScenarioFormatter from "../ScenarioFormatter";
 
 interface ScenarioGeneratorProps {
   scenarios: Scenario[];
   resultsOfSimulation: Record<string, any> | null | undefined;
-  simulationContext: Record<string, any>;
+  simulationContext?: Record<string, any>;
   setSimulationContext: (data: any) => void;
   runSimulation: () => void;
   resetTrigger: boolean;

--- a/app/components/ScenarioTester/ScenarioTester.tsx
+++ b/app/components/ScenarioTester/ScenarioTester.tsx
@@ -2,15 +2,17 @@ import { useState, useEffect, useRef } from "react";
 import { Table, Tag, Button, TableProps, Flex, Upload, message } from "antd";
 import { CheckCircleOutlined, CloseCircleOutlined } from "@ant-design/icons";
 import { UploadOutlined } from "@ant-design/icons";
+import { DecisionGraphType } from "@gorules/jdm-editor";
 import styles from "./ScenarioTester.module.css";
 import { runDecisionsForScenarios, uploadCSVAndProcess, getCSVForRuleRun } from "@/app/utils/api";
 
 interface ScenarioTesterProps {
   jsonFile: string;
+  ruleContent?: DecisionGraphType;
   uploader?: boolean;
 }
 
-export default function ScenarioTester({ jsonFile, uploader }: ScenarioTesterProps) {
+export default function ScenarioTester({ jsonFile, ruleContent, uploader }: ScenarioTesterProps) {
   const [scenarioResults, setScenarioResults] = useState<any | null>({});
   const [file, setFile] = useState<File | null>(null);
   const [uploadedFile, setUploadedFile] = useState(false);
@@ -193,7 +195,7 @@ export default function ScenarioTester({ jsonFile, uploader }: ScenarioTesterPro
 
   const updateScenarioResults = async (goRulesJSONFilename: string) => {
     try {
-      const results = await runDecisionsForScenarios(goRulesJSONFilename);
+      const results = await runDecisionsForScenarios(goRulesJSONFilename, ruleContent);
       // Loop through object and check if data.result is an array
       for (const key in results) {
         if (Array.isArray(results[key].result)) {
@@ -224,7 +226,7 @@ export default function ScenarioTester({ jsonFile, uploader }: ScenarioTesterPro
       return;
     }
     try {
-      const csvContent = await uploadCSVAndProcess(file, jsonFile);
+      const csvContent = await uploadCSVAndProcess(file, jsonFile, ruleContent);
       message.success(`Scenarios Test: ${csvContent}`);
     } catch (error) {
       message.error("Error processing scenarios.");
@@ -234,7 +236,7 @@ export default function ScenarioTester({ jsonFile, uploader }: ScenarioTesterPro
 
   const handleDownloadScenarios = async () => {
     try {
-      const csvContent = await getCSVForRuleRun(jsonFile);
+      const csvContent = await getCSVForRuleRun(jsonFile, ruleContent);
       message.success(`Scenario Testing Template: ${csvContent}`);
     } catch (error) {
       message.error("Error downloading scenarios.");

--- a/app/rule/[ruleId]/embedded/page.tsx
+++ b/app/rule/[ruleId]/embedded/page.tsx
@@ -1,16 +1,14 @@
 import SimulationViewer from "../../../components/SimulationViewer";
-import { getRuleDataById, getRuleMapByName, getScenariosByFilename } from "../../../utils/api";
-import { RuleMap } from "@/app/types/rulemap";
+import { getRuleDataById, getScenariosByFilename } from "../../../utils/api";
 import { Scenario } from "@/app/types/scenario";
 
 export default async function Rule({ params: { ruleId } }: { params: { ruleId: string } }) {
   const { _id, goRulesJSONFilename } = await getRuleDataById(ruleId);
-  const rulemap: RuleMap = await getRuleMapByName(goRulesJSONFilename);
   const scenarios: Scenario[] = await getScenariosByFilename(goRulesJSONFilename);
 
   if (!_id) {
     return <h1>Rule not found</h1>;
   }
 
-  return <SimulationViewer ruleId={ruleId} rulemap={rulemap} jsonFile={goRulesJSONFilename} scenarios={scenarios} editing={false} />;
+  return <SimulationViewer ruleId={ruleId} jsonFile={goRulesJSONFilename} scenarios={scenarios} editing={false} />;
 }

--- a/app/rule/[ruleId]/page.tsx
+++ b/app/rule/[ruleId]/page.tsx
@@ -1,13 +1,11 @@
 import RuleHeader from "@/app/components/RuleHeader";
 import SimulationViewer from "../../components/SimulationViewer";
-import { getRuleDataById, getRuleMapByName, getScenariosByFilename } from "../../utils/api";
-import { RuleMap } from "@/app/types/rulemap";
+import { getRuleDataById, getScenariosByFilename } from "../../utils/api";
 import { Scenario } from "@/app/types/scenario";
 
 export default async function Rule({ params: { ruleId } }: { params: { ruleId: string } }) {
   const ruleInfo = await getRuleDataById(ruleId);
   const { _id, goRulesJSONFilename } = ruleInfo;
-  const rulemap: RuleMap = await getRuleMapByName(goRulesJSONFilename);
   const scenarios: Scenario[] = await getScenariosByFilename(goRulesJSONFilename);
 
   if (!_id) {
@@ -17,13 +15,7 @@ export default async function Rule({ params: { ruleId } }: { params: { ruleId: s
   return (
     <>
       <RuleHeader ruleInfo={ruleInfo} />
-      <SimulationViewer
-        ruleId={ruleId}
-        rulemap={rulemap}
-        jsonFile={goRulesJSONFilename}
-        scenarios={scenarios}
-        editing
-      />
+      <SimulationViewer ruleId={ruleId} jsonFile={goRulesJSONFilename} scenarios={scenarios} editing />
     </>
   );
 }

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -1,0 +1,16 @@
+/**
+ * Downloads a file from a given data blob.
+ *
+ * @param dataBlob - The data blob to download.
+ * @param type - The type of the data blob.
+ * @param filename - The name of the file to be downloaded.
+ */
+export const downloadFileBlob = (dataBlob: any, type: string, filename: string) => {
+  const blob = new Blob([dataBlob], { type });
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  window.URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
Support to simulate on edit:
- [x] Support for being able to execute rules/simulations when the rule has been edited
- [x] Updated API and functionality to be able to execute rules from the rule graph context rather than have to look up the file
- [x] Moved ruleMap to be inside simulationViewer so that it can be controlled and updated there
- [x] Updated naming of rule graph json content to be "ruleContent" everywhere for consistency

Requires https://github.com/bcgov/brms-api/pull/21