### PR TITLE
Drafts and Review Flow

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -5,7 +5,7 @@ import { Table, Input, Button, Flex } from "antd";
 import { ColumnsType } from "antd/es/table";
 import { HomeOutlined } from "@ant-design/icons";
 import { RuleInfo } from "../types/ruleInfo";
-import { getAllRuleData, getAllRuleDocuments, postRuleData, updateRuleData, deleteRuleData } from "../utils/api";
+import { getAllRuleData, postRuleData, updateRuleData, deleteRuleData } from "../utils/api";
 
 enum ACTION_STATUS {
   NEW = "new",
@@ -32,6 +32,9 @@ export default function Admin() {
 
   const updateRule = (e: React.ChangeEvent<HTMLInputElement>, index: number, property: keyof RuleInfo) => {
     const newRules = [...rules];
+    if (property === "ruleDraft") {
+      throw new Error("Can't update the draft this way");
+    }
     newRules[index][property] = e.target.value;
     setRules(newRules);
   };

--- a/app/components/RuleHeader/RuleHeader.module.css
+++ b/app/components/RuleHeader/RuleHeader.module.css
@@ -1,7 +1,35 @@
+.headerContainer {
+  position: relative;
+  margin-bottom: 8px;
+  border-radius: 12px 12px 0 0;
+}
+
+.headerWrapper {
+  background: linear-gradient(0deg, #FFFFFF, #FFFFFFe4);
+  padding: 16px 8px 8px 8px;
+}
+
+.homeButton {
+  color: #666;
+  border: 1px solid;
+  border-radius: 10px;
+  padding: 4px 8px;
+  background: white;
+}
+
+.titleHeader {
+  margin: 0;
+}
+
 .titleInput {
   font-size: inherit;
   width: 100%;
   padding: 0;
+}
+
+.titleFilePath {
+  margin: 4px 0;
+  color: #aaa;
 }
 
 .editButton {
@@ -10,4 +38,5 @@
   cursor: pointer;
   padding: 0;
   font-size: 18px;
+  color: #4b4b4b;
 }

--- a/app/components/RuleHeader/RuleHeader.test.js
+++ b/app/components/RuleHeader/RuleHeader.test.js
@@ -1,10 +1,21 @@
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import { toBeInTheDocument } from "@testing-library/jest-dom";
-import RuleHeader from "./RuleHeader";
 import api from "@/app/utils/api";
+import RuleHeader from "./RuleHeader";
 
 jest.mock("../../utils/api", () => ({
   updateRuleData: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter() {
+    return {
+      push: jest.fn(),
+    };
+  },
+  usePathname() {
+    return "/rule/123";
+  },
 }));
 
 describe("RuleHeader - doneEditingTitle", () => {

--- a/app/components/SavePublish/NewReviewForm.tsx
+++ b/app/components/SavePublish/NewReviewForm.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Button, Form, Input } from "antd";
+import { generateBranchName, generateReviewMessage } from "@/app/utils/githubApi";
+
+interface NewReviewFormProps {
+  filePath: string;
+  createNewReview: ({
+    newReviewBranch,
+    reviewDescription,
+  }: {
+    newReviewBranch: string;
+    reviewDescription: string;
+  }) => void;
+}
+
+export default function NewReviewForm({ filePath, createNewReview }: NewReviewFormProps) {
+  return (
+    <Form
+      name="basic"
+      initialValues={{
+        remember: true,
+        newReviewBranch: generateBranchName(filePath),
+        reviewDescription: generateReviewMessage(false, filePath),
+      }}
+      onFinish={createNewReview}
+      autoComplete="off"
+    >
+      <br />
+      <Form.Item
+        label="Branch name"
+        name="newReviewBranch"
+        rules={[
+          {
+            required: true,
+            message:
+              "Branch names can include letters, numbers, dashes (-), underscores (_), and dots (.), but they cannot begin with a dot or end with a slash (/)",
+            pattern: /^(?!\.)[a-zA-Z0-9\-_./]+(?<!\/)$/,
+          },
+        ]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        label="Review description"
+        name="reviewDescription"
+        rules={[{ required: true, message: "Please input a description for review" }]}
+      >
+        <Input.TextArea rows={5} />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          Submit for Review
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/app/components/SavePublish/SavePublish.module.css
+++ b/app/components/SavePublish/SavePublish.module.css
@@ -1,0 +1,10 @@
+.savePublishWrapper {
+    background: #f7f9fc;
+    padding: 16px;
+    border-bottom: 1px solid #d9d9d9;
+}
+
+.sendForReviewBtn {
+    background: orange !important;
+    border-color: orange !important;
+}

--- a/app/components/SavePublish/SavePublish.tsx
+++ b/app/components/SavePublish/SavePublish.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from "react";
+import { Modal, Button, Flex, message } from "antd";
+import { SaveOutlined, UploadOutlined } from "@ant-design/icons";
+import { RuleInfo } from "@/app/types/ruleInfo";
+import { updateRuleData } from "@/app/utils/api";
+import { sendRuleForReview } from "@/app/utils/githubApi";
+import NewReviewForm from "./NewReviewForm";
+import styles from "./SavePublish.module.css";
+
+interface SavePublishProps {
+  ruleInfo: RuleInfo;
+  ruleContent: object;
+}
+
+export default function SavePublish({ ruleInfo, ruleContent }: SavePublishProps) {
+  const { _id: ruleId, goRulesJSONFilename: filePath, reviewBranch } = ruleInfo;
+
+  const [openNewReviewModal, setOpenNewReviewModal] = useState(false);
+  const [currReviewBranch, setCurrReviewBranch] = useState(reviewBranch);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSendingToReview, setIsSendingToReview] = useState(false);
+
+  const save = async () => {
+    setIsSaving(true);
+    try {
+      await updateRuleData(ruleId, { ruleDraft: { content: ruleContent } });
+      message.success("Draft saved");
+    } catch (e) {
+      message.error("Failed to save draft");
+    }
+    setIsSaving(false);
+  };
+
+  const createOrUpdateReview = async (newReviewBranch?: string, reviewDescription: string = "") => {
+    setIsSaving(true);
+    setIsSendingToReview(true);
+    // Save before sending to review
+    await updateRuleData(ruleId, { ruleDraft: { content: ruleContent } });
+    // Prompt for new review branch details if they don't exist
+    const branch = currReviewBranch || newReviewBranch;
+    if (!branch) {
+      setOpenNewReviewModal(true);
+      return;
+    }
+    setOpenNewReviewModal(false);
+    try {
+      await sendRuleForReview(ruleContent, branch, filePath, reviewDescription);
+      await updateRuleData(ruleId, { reviewBranch: branch });
+      if (newReviewBranch) {
+        setCurrReviewBranch(newReviewBranch);
+      }
+      message.success("Review updated/created");
+    } catch (e) {
+      console.error("Unable to update/create review");
+      message.error("Unable to update/create review");
+    }
+    setIsSaving(false);
+    setIsSendingToReview(false);
+  };
+
+  const createNewReview = ({
+    newReviewBranch,
+    reviewDescription,
+  }: {
+    newReviewBranch: string;
+    reviewDescription: string;
+  }) => {
+    createOrUpdateReview(newReviewBranch, reviewDescription);
+  };
+
+  return (
+    <>
+      <Modal
+        title="New Review"
+        open={openNewReviewModal}
+        centered
+        footer={null}
+        onCancel={() => setOpenNewReviewModal(false)}
+      >
+        <NewReviewForm filePath={filePath} createNewReview={createNewReview} />
+      </Modal>
+      <Flex gap="small" justify="end" className={styles.savePublishWrapper}>
+        <Button type="primary" onClick={save} disabled={isSaving}>
+          Save <SaveOutlined />
+        </Button>
+        <Button
+          type="primary"
+          onClick={() => createOrUpdateReview()}
+          className={styles.sendForReviewBtn}
+          disabled={isSendingToReview}
+        >
+          {" "}
+          Send for Review <UploadOutlined />
+        </Button>
+      </Flex>
+    </>
+  );
+}

--- a/app/components/SavePublish/index.ts
+++ b/app/components/SavePublish/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SavePublish";

--- a/app/constants/defaultRuleContent.ts
+++ b/app/constants/defaultRuleContent.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_RULE_CONTENT = { contentType: "application/vnd.gorules.decision", nodes: [], edges: [] };

--- a/app/constants/ruleVersion.ts
+++ b/app/constants/ruleVersion.ts
@@ -1,0 +1,5 @@
+export enum RULE_VERSION {
+  draft = "draft",
+  inReview = "inReview",
+  published = "published",
+}

--- a/app/hooks/getRuleDataForVersion.ts
+++ b/app/hooks/getRuleDataForVersion.ts
@@ -1,0 +1,44 @@
+import { RuleInfo } from "../types/ruleInfo";
+import { RULE_VERSION } from "../constants/ruleVersion";
+import { getFileAsJsonIfAlreadyExists } from "../utils/githubApi";
+import { getRuleDraft, getDocument, getRuleDataById } from "../utils/api";
+import { DEFAULT_RULE_CONTENT } from "../constants/defaultRuleContent";
+
+export default async function getRuleDataForVersion(ruleId: string, version?: string) {
+  // Get rule data
+  const ruleInfo: RuleInfo = await getRuleDataById(ruleId);
+
+  // Get the rule content based on version and ruleInfo
+  let ruleContent;
+  try {
+    switch (version) {
+      case RULE_VERSION.draft:
+        const draft = await getRuleDraft(ruleId);
+        ruleContent = draft?.content;
+        // If no current draft, create one using what's currently published as a base
+        if (!ruleContent) {
+          ruleContent = await getPublishedRuleContentOrDefault(ruleInfo);
+        }
+        break;
+      case RULE_VERSION.inReview:
+        if (!ruleInfo.reviewBranch) {
+          throw new Error("No branch in review");
+        }
+        ruleContent = await getFileAsJsonIfAlreadyExists(ruleInfo.reviewBranch, ruleInfo.goRulesJSONFilename);
+        break;
+      default:
+        ruleContent = await getDocument(ruleInfo.goRulesJSONFilename);
+    }
+  } catch (error) {
+    console.error("Error fetching rule content:", error);
+  }
+
+  return { ruleInfo, ruleContent };
+}
+
+async function getPublishedRuleContentOrDefault(ruleInfo: RuleInfo) {
+  if (ruleInfo.goRulesJSONFilename) {
+    return await getDocument(ruleInfo.goRulesJSONFilename);
+  }
+  return DEFAULT_RULE_CONTENT;
+}

--- a/app/rule/[ruleId]/embedded/page.tsx
+++ b/app/rule/[ruleId]/embedded/page.tsx
@@ -1,14 +1,20 @@
+import getRuleDataForVersion from "@/app/hooks/getRuleDataForVersion";
 import SimulationViewer from "../../../components/SimulationViewer";
-import { getRuleDataById, getScenariosByFilename } from "../../../utils/api";
+import { getScenariosByFilename } from "../../../utils/api";
 import { Scenario } from "@/app/types/scenario";
+import { RULE_VERSION } from "@/app/constants/ruleVersion";
 
 export default async function Rule({ params: { ruleId } }: { params: { ruleId: string } }) {
-  const { _id, goRulesJSONFilename } = await getRuleDataById(ruleId);
-  const scenarios: Scenario[] = await getScenariosByFilename(goRulesJSONFilename);
+  // Get rule details and json content for the rule id
+  const { ruleInfo, ruleContent } = await getRuleDataForVersion(ruleId, RULE_VERSION.published);
 
-  if (!_id) {
+  if (!ruleInfo._id || !ruleContent) {
     return <h1>Rule not found</h1>;
   }
+  // Get scenario information
+  const scenarios: Scenario[] = await getScenariosByFilename(ruleInfo.goRulesJSONFilename);
 
-  return <SimulationViewer ruleId={ruleId} jsonFile={goRulesJSONFilename} scenarios={scenarios} editing={false} />;
+  return (
+    <SimulationViewer ruleInfo={ruleInfo} initialRuleContent={ruleContent} scenarios={scenarios} editing={false} />
+  );
 }

--- a/app/rule/[ruleId]/page.tsx
+++ b/app/rule/[ruleId]/page.tsx
@@ -1,27 +1,45 @@
-import { getScenariosByFilename, getRuleDataById } from "@/app/utils/api";
+import { getScenariosByFilename } from "@/app/utils/api";
 import RuleHeader from "@/app/components/RuleHeader";
 import SimulationViewer from "@/app/components/SimulationViewer";
 import { Scenario } from "@/app/types/scenario";
+import getRuleDataForVersion from "@/app/hooks/getRuleDataForVersion";
+import { RULE_VERSION } from "@/app/constants/ruleVersion";
 import { GithubAuthProvider } from "@/app/components/GithubAuthProvider";
 import useGithubAuth from "@/app/hooks/useGithubAuth";
 
-export default async function Rule({ params: { ruleId } }: { params: { ruleId: string } }) {
-  const ruleInfo = await getRuleDataById(ruleId);
-  const { _id, goRulesJSONFilename } = ruleInfo;
-  const scenarios: Scenario[] = await getScenariosByFilename(goRulesJSONFilename);
+export default async function Rule({
+  params: { ruleId },
+  searchParams,
+}: {
+  params: { ruleId: string };
+  searchParams: { version?: string };
+}) {
+  // Get version of rule to use
+  const { version } = searchParams;
 
   // Ensure user is first logged into github so they can save what they edit
   // If they are not, redirect them to the oauth flow
   const { githubAuthToken, githubAuthUsername } = await useGithubAuth(`rule/${ruleId}`);
 
-  if (!_id) {
+  // Get rule details and json content for the rule id
+  const { ruleInfo, ruleContent } = await getRuleDataForVersion(ruleId, version);
+
+  if (!ruleInfo._id || !ruleContent) {
     return <h1>Rule not found</h1>;
   }
 
+  // Get scenario information
+  const scenarios: Scenario[] = await getScenariosByFilename(ruleInfo.goRulesJSONFilename);
+
   return (
     <GithubAuthProvider authInfo={{ githubAuthToken, githubAuthUsername }}>
-      <RuleHeader ruleInfo={ruleInfo} />
-      <SimulationViewer ruleId={_id} jsonFile={goRulesJSONFilename} scenarios={scenarios} editing />
+      <RuleHeader ruleInfo={ruleInfo} version={version} />
+      <SimulationViewer
+        ruleInfo={ruleInfo}
+        initialRuleContent={ruleContent}
+        scenarios={scenarios}
+        editing={version === RULE_VERSION.draft}
+      />
     </GithubAuthProvider>
   );
 }

--- a/app/styles/themeConfig.ts
+++ b/app/styles/themeConfig.ts
@@ -9,6 +9,9 @@ const theme: ThemeConfig = {
     Select: {
       optionFontSize: 16,
     },
+    List: {
+      itemPaddingSM: "4px 0px",
+    },
   },
 };
 

--- a/app/types/ruleInfo.d.ts
+++ b/app/types/ruleInfo.d.ts
@@ -1,5 +1,12 @@
+export interface RuleDraft {
+  _id: string;
+  content: DecisionGraphType;
+}
+
 export interface RuleInfo {
   _id: string;
-  title: string;
+  title?: string;
   goRulesJSONFilename: string;
+  ruleDraft?: RuleDraft;
+  reviewBranch?: string;
 }

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -1,12 +1,12 @@
 import { DecisionGraphType } from "@gorules/jdm-editor";
 import axios from "axios";
-import { RuleInfo } from "../types/ruleInfo";
+import { RuleDraft, RuleInfo } from "../types/ruleInfo";
 import { RuleMap } from "../types/rulemap";
 import { downloadFileBlob } from "./utils";
 
 const axiosAPIInstance = axios.create({
   // For server side calls, need full URL, otherwise can just use /api
-  baseURL: typeof window === "undefined" ? process.env.NEXT_PUBLIC_API_URL : "/api",
+  baseURL: typeof window === "undefined" ? `${process.env.NEXT_PUBLIC_SERVER_URL}/api` : "/api",
   headers: {
     "Content-Type": "application/json",
   },
@@ -21,6 +21,22 @@ const axiosAPIInstance = axios.create({
 export const getRuleDataById = async (ruleId: string): Promise<RuleInfo> => {
   try {
     const { data } = await axiosAPIInstance.get(`/ruleData/${ruleId}`);
+    return data;
+  } catch (error) {
+    console.error(`Error getting rule data: ${error}`);
+    throw error;
+  }
+};
+
+/**
+ * Retrieves the draft of a rule if it exists
+ * @param ruleId The ID of the rule data to retrieve.
+ * @returns The draft json
+ * @throws If an error occurs while retrieving the rule draft
+ */
+export const getRuleDraft = async (ruleId: string): Promise<RuleDraft> => {
+  try {
+    const { data } = await axiosAPIInstance.get(`/ruleData/draft/${ruleId}?_=${new Date().getTime()}`);
     return data;
   } catch (error) {
     console.error(`Error getting rule data: ${error}`);

--- a/app/utils/githubApi.ts
+++ b/app/utils/githubApi.ts
@@ -147,7 +147,7 @@ const createPR = async (branchName: string, prTitle: string, reviewDescription: 
     const prUrl = `${GITHUB_REPO_URL}/pulls`;
     const prResponse = await axiosGithubInstance.post(prUrl, {
       title: prTitle,
-      description: reviewDescription,
+      body: reviewDescription,
       head: branchName,
       base: GITHUB_BASE_BRANCH,
     });


### PR DESCRIPTION
- [x] Changed where/how the content is fetched
- [x] Added support for "versions" (draft, inReview, published)
- [x] Added support for drafts and in review content (as well as changed how published works)
- [x] Updated how new rules are created to work fully
- [x] Created new save and "send for review" controls when editing a draft
- [x] Created "new review" form
- [x] Updated header to support new versions functionality

See diagram for new proposed flow (note that pipeline changes have not been implemented and may still need more thought):
<img width="2628" alt="Draft -_ Dev Process" src="https://github.com/user-attachments/assets/11077853-77a9-4acc-9b7d-3275c8591366">

