### PR TITLE
Added new custom input/output fields to request/response components

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install ESLint
         run: |
-          npm install eslint@8.10.0
+          npm install eslint@8.56.0 --no-strict-ssl --no-shrinkwrap
 
       - name: Run ESLint
         run: npm run lint:pipeline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --no-strict-ssl --no-shrinkwrap
 
       - name: Run Jest tests with coverage
         run: npm test -- --coverage

--- a/app/components/RuleViewerEditor/RuleViewerEditor.tsx
+++ b/app/components/RuleViewerEditor/RuleViewerEditor.tsx
@@ -2,6 +2,8 @@
 import { useState, useMemo, useEffect, useRef } from "react";
 import type { ReactFlowInstance } from "reactflow";
 import "@gorules/jdm-editor/dist/style.css";
+import { Spin } from "antd";
+import { ApartmentOutlined, PlayCircleOutlined, LoginOutlined, LogoutOutlined } from "@ant-design/icons";
 import {
   JdmConfigProvider,
   DecisionGraph,
@@ -10,21 +12,22 @@ import {
   DecisionGraphRef,
   Simulation,
 } from "@gorules/jdm-editor";
-import { ApartmentOutlined, PlayCircleOutlined } from "@ant-design/icons";
+import { SchemaSelectProps } from "@gorules/jdm-editor/src/helpers/components";
 import { Scenario, Variable } from "@/app/types/scenario";
+import { downloadFileBlob } from "@/app/utils/utils";
+import { getScenariosByFilename } from "@/app/utils/api";
 import LinkRuleComponent from "./subcomponents/LinkRuleComponent";
 import SimulatorPanel from "./subcomponents/SimulatorPanel";
-import { downloadFileBlob } from "@/app/utils/utils";
-import { getScenariosByFilename } from "../../utils/api";
+import RuleInputsComponent from "./subcomponents/RuleInputOutputFieldsComponent";
 
 interface RuleViewerEditorProps {
   jsonFilename: string;
   ruleContent: DecisionGraphType;
   updateRuleContent: (updateGraph: DecisionGraphType) => void;
   contextToSimulate?: Record<string, any> | null;
-  setContextToSimulate: (results: Record<string, any>) => void;
+  setContextToSimulate?: (results: Record<string, any>) => void;
   simulation?: Simulation;
-  runSimulation: (results: unknown) => void;
+  runSimulation?: (results: unknown) => void;
   isEditable?: boolean;
 }
 
@@ -40,6 +43,8 @@ export default function RuleViewerEditor({
 }: RuleViewerEditorProps) {
   const decisionGraphRef: any = useRef<DecisionGraphRef>();
   const [reactFlowRef, setReactFlowRef] = useState<ReactFlowInstance>();
+  const [inputsSchema, setInputsSchema] = useState<SchemaSelectProps[]>([]);
+  const [outputsSchema, setOutputsSchema] = useState<SchemaSelectProps[]>([]);
 
   useEffect(() => {
     // Ensure graph is in view
@@ -116,9 +121,9 @@ export default function RuleViewerEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ruleContent]);
 
-  // This is to add the decision node - note that this may be added to the DecisionGraph library
   const additionalComponents: NodeSpecification[] = useMemo(
     () => [
+      // This is to add the decision node - note that this may be added to the DecisionGraph library eventually
       {
         type: "decisionNode",
         displayName: "Rule",
@@ -133,6 +138,54 @@ export default function RuleViewerEditor({
             isSelected={selected}
             name={data?.name}
             isEditable={isEditable}
+          />
+        ),
+      },
+      // Input node - overrides existing one (but duplication occurs atm)
+      {
+        type: "inputNode",
+        displayName: "Request",
+        shortDescription: "Provides input context",
+        color: "secondary",
+        icon: <LoginOutlined />,
+        disabled: true,
+        generateNode: ({ index }) => ({
+          name: "Request",
+          type: "inputNode",
+          content: { fields: [] },
+        }),
+        renderNode: ({ specification, id, selected, data }) => (
+          <RuleInputsComponent
+            specification={specification}
+            id={id}
+            isSelected={selected}
+            name={data?.name}
+            isEditable={isEditable}
+            setInputOutputSchema={setInputsSchema}
+          />
+        ),
+      },
+      // Output node - overrides existing one (but duplication occurs atm)
+      {
+        type: "outputNode",
+        displayName: "Response",
+        shortDescription: "Outputs the context",
+        color: "secondary",
+        icon: <LogoutOutlined />,
+        disabled: true,
+        generateNode: ({ index }) => ({
+          name: "Response",
+          type: "outputNode",
+          content: { fields: [] },
+        }),
+        renderNode: ({ specification, id, selected, data }) => (
+          <RuleInputsComponent
+            specification={specification}
+            id={id}
+            isSelected={selected}
+            name={data?.name}
+            isEditable={isEditable}
+            setInputOutputSchema={setOutputsSchema}
           />
         ),
       },
@@ -159,6 +212,14 @@ export default function RuleViewerEditor({
     [contextToSimulate, runSimulation, setContextToSimulate]
   );
 
+  if (!ruleContent || !additionalComponents || !panels) {
+    return (
+      <Spin tip="Loading graph..." size="large" className="spinner">
+        <div className="content" />
+      </Spin>
+    );
+  }
+
   return (
     <JdmConfigProvider>
       <DecisionGraph
@@ -172,6 +233,8 @@ export default function RuleViewerEditor({
         components={additionalComponents}
         onChange={(updatedGraphValue) => updateRuleContent(updatedGraphValue)}
         disabled={!isEditable}
+        inputsSchema={inputsSchema}
+        outputsSchema={outputsSchema}
       />
     </JdmConfigProvider>
   );

--- a/app/components/RuleViewerEditor/RuleViewerEditor.tsx
+++ b/app/components/RuleViewerEditor/RuleViewerEditor.tsx
@@ -18,7 +18,7 @@ import { downloadFileBlob } from "@/app/utils/utils";
 import { getScenariosByFilename } from "@/app/utils/api";
 import LinkRuleComponent from "./subcomponents/LinkRuleComponent";
 import SimulatorPanel from "./subcomponents/SimulatorPanel";
-import RuleInputsComponent from "./subcomponents/RuleInputOutputFieldsComponent";
+import RuleInputOutputFieldsComponent from "./subcomponents/RuleInputOutputFieldsComponent";
 
 interface RuleViewerEditorProps {
   jsonFilename: string;
@@ -155,13 +155,14 @@ export default function RuleViewerEditor({
           content: { fields: [] },
         }),
         renderNode: ({ specification, id, selected, data }) => (
-          <RuleInputsComponent
+          <RuleInputOutputFieldsComponent
             specification={specification}
             id={id}
             isSelected={selected}
             name={data?.name}
-            isEditable={isEditable}
+            fieldsTypeLabel="Input"
             setInputOutputSchema={setInputsSchema}
+            isEditable={isEditable}
           />
         ),
       },
@@ -179,13 +180,14 @@ export default function RuleViewerEditor({
           content: { fields: [] },
         }),
         renderNode: ({ specification, id, selected, data }) => (
-          <RuleInputsComponent
+          <RuleInputOutputFieldsComponent
             specification={specification}
             id={id}
             isSelected={selected}
             name={data?.name}
-            isEditable={isEditable}
+            fieldsTypeLabel="Output"
             setInputOutputSchema={setOutputsSchema}
+            isEditable={isEditable}
           />
         ),
       },

--- a/app/components/RuleViewerEditor/subcomponents/RuleInputOutputFieldsComponent.module.css
+++ b/app/components/RuleViewerEditor/subcomponents/RuleInputOutputFieldsComponent.module.css
@@ -1,0 +1,4 @@
+.selectDescription {
+  font-size: 12px;
+  display: block;
+}

--- a/app/components/RuleViewerEditor/subcomponents/RuleInputOutputFieldsComponent.tsx
+++ b/app/components/RuleViewerEditor/subcomponents/RuleInputOutputFieldsComponent.tsx
@@ -18,6 +18,7 @@ declare type InputOutputField = {
 };
 
 interface RuleInputOutputFieldsComponent extends GraphNodeProps {
+  fieldsTypeLabel: string;
   setInputOutputSchema: (schema: SchemaSelectProps[]) => void;
   isEditable: boolean;
 }
@@ -27,6 +28,7 @@ export default function RuleInputOutputFieldsComponent({
   id,
   isSelected,
   name,
+  fieldsTypeLabel = "Input",
   setInputOutputSchema,
   isEditable,
 }: RuleInputOutputFieldsComponent) {
@@ -146,7 +148,7 @@ export default function RuleInputOutputFieldsComponent({
         isEditable
           ? [
               <Button key="add row" type="link" onClick={addInputField} disabled={!isEditable}>
-                Add Input +
+                Add {fieldsTypeLabel} +
               </Button>,
             ]
           : []
@@ -167,7 +169,7 @@ export default function RuleInputOutputFieldsComponent({
                     filterOption={filterOption}
                     options={inputOutputOptions}
                     onChange={(value) => updateInputField(item, value)}
-                    value={item.field}
+                    value={{ label: item.label, value: item.field }}
                     notFoundContent={isLoading ? <Spin size="small" /> : null}
                     style={{ width: 200 }}
                     popupMatchSelectWidth={false}

--- a/app/components/RuleViewerEditor/subcomponents/RuleInputOutputFieldsComponent.tsx
+++ b/app/components/RuleViewerEditor/subcomponents/RuleInputOutputFieldsComponent.tsx
@@ -1,0 +1,197 @@
+import React, { useState, useEffect } from "react";
+import { Button, List, Select, Spin, Tooltip } from "antd";
+import { DeleteOutlined } from "@ant-design/icons";
+import type { BaseOptionType } from "antd/es/select";
+import type { FlattenOptionData } from "rc-select/lib/interface";
+import { GraphNode, useDecisionGraphActions, useDecisionGraphState } from "@gorules/jdm-editor";
+import type { GraphNodeProps } from "@gorules/jdm-editor";
+import { SchemaSelectProps } from "@gorules/jdm-editor/src/helpers/components";
+import { KlammBREField } from "@/app/types/klamm";
+import { getBREFields } from "@/app/utils/api";
+import styles from "./RuleInputOutputFieldsComponent.module.css";
+
+declare type InputOutputField = {
+  id?: string;
+  field: string;
+  label?: string;
+  type?: string;
+};
+
+interface RuleInputOutputFieldsComponent extends GraphNodeProps {
+  setInputOutputSchema: (schema: SchemaSelectProps[]) => void;
+  isEditable: boolean;
+}
+
+export default function RuleInputOutputFieldsComponent({
+  specification,
+  id,
+  isSelected,
+  name,
+  setInputOutputSchema,
+  isEditable,
+}: RuleInputOutputFieldsComponent) {
+  const { updateNode } = useDecisionGraphActions();
+  const node = useDecisionGraphState((state) => (state.decisionGraph?.nodes || []).find((n) => n.id === id));
+  const inputOutputFields: InputOutputField[] = node?.content?.fields || [];
+
+  const [inputOutputOptions, setInputOutputOptions] = useState<BaseOptionType[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const getFieldsFromKlamm = async () => {
+      try {
+        const data: KlammBREField[] = await getBREFields();
+        const newInputOutputOptions: BaseOptionType[] = data.map(({ id, name, label, description }) => ({
+          label: `${label}${description ? `: ${description}` : ""}`, // Add the description as part of the label - will be formatted properly later
+          value: name,
+        }));
+        setInputOutputOptions(newInputOutputOptions);
+        setIsLoading(false);
+      } catch (error) {
+        console.error("Error:", error);
+      }
+    };
+    getFieldsFromKlamm();
+  }, []);
+
+  useEffect(() => {
+    // Add a new field by default if one doesn't exist when editing
+    if (isEditable && inputOutputFields?.length == 0) {
+      updateNode(id, (draft) => {
+        draft.content = { fields: [{ id: crypto.randomUUID(), field: "" }] };
+        return draft;
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (inputOutputFields?.length == 0) return;
+    // Map the fields from the schema - basically just converting label to name
+    const schemafiedInputs = inputOutputFields
+      .filter(({ field }) => field)
+      .map(({ field, label }) => ({ field, name: label }));
+    setInputOutputSchema(schemafiedInputs);
+  }, [inputOutputFields]);
+
+  const addInputField = () => {
+    updateNode(id, (draft) => {
+      if (!draft.content?.fields) {
+        draft.content = { fields: [] };
+      }
+      draft.content.fields.push({ id: crypto.randomUUID(), field: "" });
+      return draft;
+    });
+  };
+
+  const updateInputField = (item: InputOutputField, { key, label }: any) => {
+    updateNode(id, (draft) => {
+      draft.content.fields = draft.content.fields.map((input: InputOutputField) => {
+        if (input.id === item.id) {
+          input.field = key;
+          input.label = label;
+        }
+        return input;
+      });
+      return draft;
+    });
+  };
+
+  const deleteInputField = (item: InputOutputField) => {
+    updateNode(id, (draft) => {
+      draft.content.fields = draft.content.fields.filter((input: InputOutputField) => input.id !== item.id);
+      return draft;
+    });
+  };
+
+  const filterOption = (inputValue: string, option?: BaseOptionType) =>
+    (option?.label ?? "").toString().toLowerCase().includes(inputValue.toLowerCase());
+
+  const renderSelectLabel = ({ label }: { label: React.ReactNode }) => {
+    if (!label) {
+      return null;
+    }
+    const [name] = label?.toString().split(":"); // first part of label is the name (don't want description here)
+    return name;
+  };
+
+  const renderSelectOption = ({ label }: FlattenOptionData<BaseOptionType>) => {
+    if (!label) {
+      return null;
+    }
+    const [name, description] = label?.toString().split(":");
+    return (
+      <>
+        <span>{name}</span>
+        {description ? <span className={styles.selectDescription}>{description}</span> : ""}
+      </>
+    );
+  };
+
+  const renderLabel = (label: string) => {
+    const [name, description] = label?.toString().split(":");
+    return (
+      <Tooltip title={description} placement="left">
+        <span>{name}</span>
+      </Tooltip>
+    );
+  };
+
+  return (
+    <GraphNode
+      id={id}
+      specification={specification}
+      name={name}
+      isSelected={isSelected}
+      actions={
+        isEditable
+          ? [
+              <Button key="add row" type="link" onClick={addInputField} disabled={!isEditable}>
+                Add Input +
+              </Button>,
+            ]
+          : []
+      }
+    >
+      {inputOutputFields && inputOutputFields.length > 0 && (
+        <List
+          size="small"
+          dataSource={inputOutputFields}
+          renderItem={(item) => (
+            <List.Item>
+              {isEditable ? (
+                <>
+                  <Select
+                    disabled={!isEditable}
+                    showSearch
+                    placeholder="Select rule"
+                    filterOption={filterOption}
+                    options={inputOutputOptions}
+                    onChange={(value) => updateInputField(item, value)}
+                    value={item.field}
+                    notFoundContent={isLoading ? <Spin size="small" /> : null}
+                    style={{ width: 200 }}
+                    popupMatchSelectWidth={false}
+                    className={styles.inputSelect}
+                    labelInValue
+                    labelRender={renderSelectLabel}
+                    optionRender={renderSelectOption}
+                  />
+                  <Button
+                    type="text"
+                    danger
+                    icon={<DeleteOutlined />}
+                    style={{ marginLeft: "4px" }}
+                    onClick={() => deleteInputField(item)}
+                    disabled={!isEditable}
+                  />
+                </>
+              ) : (
+                item.label && <span>{renderLabel(item.label)}</span>
+              )}
+            </List.Item>
+          )}
+        />
+      )}
+    </GraphNode>
+  );
+}

--- a/app/types/klamm.d.ts
+++ b/app/types/klamm.d.ts
@@ -1,0 +1,6 @@
+export interface KlammBREField {
+  id: string;
+  name: string;
+  label: string;
+  description?: string;
+}

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -2,6 +2,7 @@ import { DecisionGraphType } from "@gorules/jdm-editor";
 import axios from "axios";
 import { RuleDraft, RuleInfo } from "../types/ruleInfo";
 import { RuleMap } from "../types/rulemap";
+import { KlammBREField } from "../types/klamm";
 import { downloadFileBlob } from "./utils";
 
 const axiosAPIInstance = axios.create({
@@ -349,5 +350,22 @@ export const uploadCSVAndProcess = async (
   } catch (error) {
     console.error(`Error processing CSV file: ${error}`);
     throw new Error("Error processing CSV file");
+  }
+};
+
+/**
+ * Retrieves a list of bre fields from Klamm
+ * @returns List of bre fields
+ * @throws If an error occurs while retrieving the fields
+ */
+export const getBREFields = async (): Promise<KlammBREField[]> => {
+  try {
+    const {
+      data: { data },
+    } = await axiosAPIInstance.get("/klamm/brefields");
+    return data;
+  } catch (error) {
+    console.error(`Error getting rule data: ${error}`);
+    throw error;
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/nextjs-registry": "^1.0.0",
-        "@gorules/jdm-editor": "https://gitpkg.vercel.app/bcgov/jdm-editor/packages/jdm-editor?feature/input-output-schema-support",
-        "@gorules/jdm-monorepo": "bcgov/jdm-editor#feature/input-output-schema-support",
+        "@gorules/jdm-editor": "https://gitpkg.vercel.app/bcgov/jdm-editor/packages/jdm-editor?master",
+        "@gorules/jdm-monorepo": "bcgov/jdm-editor",
         "@rjsf/core": "^5.17.1",
         "@rjsf/utils": "^5.17.1",
         "@rjsf/validator-ajv8": "^5.17.1",
@@ -963,8 +963,8 @@
     },
     "node_modules/@gorules/jdm-editor": {
       "version": "1.15.0",
-      "resolved": "https://gitpkg.vercel.app/bcgov/jdm-editor/packages/jdm-editor?feature/input-output-schema-support",
-      "integrity": "sha512-VKIve/fZlQwL7QLh+GyGfB414V4sJqBuMcXTAvmIa6uovud0gDdSS7OFTbK6HXDdtgs/B8YZfoHEIzvtsKKeTg==",
+      "resolved": "https://gitpkg.vercel.app/bcgov/jdm-editor/packages/jdm-editor?master",
+      "integrity": "sha512-0uVmSSLVB/D6dza+pPR1Ta9HFwGd4bVnTtrlCofUCWkijn56DjL2s1kO4PV1mI0W4Uj1FXqjw6JdjvcvogSbow==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/icons": "5.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/nextjs-registry": "^1.0.0",
-        "@gorules/jdm-editor": "^1.9.0",
+        "@gorules/jdm-editor": "https://gitpkg.vercel.app/bcgov/jdm-editor/packages/jdm-editor?feature/input-output-schema-support",
+        "@gorules/jdm-monorepo": "bcgov/jdm-editor#feature/input-output-schema-support",
         "@rjsf/core": "^5.17.1",
         "@rjsf/utils": "^5.17.1",
         "@rjsf/validator-ajv8": "^5.17.1",
@@ -18,7 +19,8 @@
         "json5": "^2.2.3",
         "next": "14.1.0",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "reactflow": "^11.11.4"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.5",
@@ -32,7 +34,33 @@
         "eslint-config-next": "14.1.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5"
+      }
+    },
+    "../jdm-editor": {
+      "name": "@gorules/jdm-monorepo",
+      "version": "0.1.0",
+      "extraneous": true,
+      "devDependencies": {
+        "@swc/core": "^1.5.7",
+        "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+        "@types/node": "^20.12.12",
+        "@types/react": "^18.3.3",
+        "@typescript-eslint/eslint-plugin": "^7.10.0",
+        "@typescript-eslint/parser": "^7.10.0",
+        "eslint": "8.56.0",
+        "eslint-config-prettier": "9.1.0",
+        "eslint-plugin-file-progress": "^1.4.0",
+        "eslint-plugin-react": "^7.34.1",
+        "eslint-plugin-react-hooks": "^4.6.2",
+        "lerna": "^8.1.3",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^3.2.5",
+        "typescript": "^5.4.5"
+      },
+      "engines": {
+        "pnpm": "~9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -746,9 +774,9 @@
       "dev": true
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.16.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.16.3.tgz",
-      "integrity": "sha512-Vl/tIeRVVUCRDuOG48lttBasNQu8usGgXQawBXI7WJAiUDSFOfzflmEsZFZo48mAvAaa4FZ/4/yLLxFtdJaKYA==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.0.tgz",
+      "integrity": "sha512-5DbOvBbY4qW5l57cjDsmmpDh3/TeK1vXfTHa+BUMrRzdWdcxKZ4U4V7vQaTtOpApNU4kLS4FQ6cINtLg245LXA==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -791,9 +819,9 @@
       "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A=="
     },
     "node_modules/@codemirror/view": {
-      "version": "6.28.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.28.2.tgz",
-      "integrity": "sha512-A3DmyVfjgPsGIjiJqM/zvODUAPQdQl3ci0ghehYNnbt5x+o76xq+dL5+mMBuysDXnI3kapgOkoeJ0sbtL/3qPw==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.33.0.tgz",
+      "integrity": "sha512-AroaR3BvnjRW8fiZBalAaK+ZzB5usGgI014YKElYZvQdNH5ZIidHlO+cyf/2rWzyBFRkvG6VhiXeAEbC53P2YQ==",
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -805,8 +833,6 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -819,8 +845,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -938,9 +962,10 @@
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "node_modules/@gorules/jdm-editor": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@gorules/jdm-editor/-/jdm-editor-1.9.0.tgz",
-      "integrity": "sha512-5LPtAgIcVVuwYtRPFqWZ2vC8rnVRRDHezATamsWF6ZhuFOa7mKOdc+qmmlI0sVCYPTejgtmHn2wb6rhuugjNJQ==",
+      "version": "1.15.0",
+      "resolved": "https://gitpkg.vercel.app/bcgov/jdm-editor/packages/jdm-editor?feature/input-output-schema-support",
+      "integrity": "sha512-VKIve/fZlQwL7QLh+GyGfB414V4sJqBuMcXTAvmIa6uovud0gDdSS7OFTbK6HXDdtgs/B8YZfoHEIzvtsKKeTg==",
+      "license": "MIT",
       "dependencies": {
         "@ant-design/icons": "5.3.7",
         "@codemirror/autocomplete": "^6.16.0",
@@ -948,7 +973,7 @@
         "@codemirror/lint": "^6.8.1",
         "@codemirror/state": "^6.4.1",
         "@codemirror/view": "^6.26.3",
-        "@gorules/lezer-zen": "0.3.0",
+        "@gorules/lezer-zen": "0.4.0",
         "@gorules/lezer-zen-template": "0.2.0",
         "@lezer/common": "^1.2.1",
         "@lezer/highlight": "^1.2.0",
@@ -964,7 +989,7 @@
         "fast-deep-equal": "^3.1.3",
         "immer": "10.1.1",
         "json5": "^2.2.3",
-        "monaco-editor": "^0.48.0",
+        "monaco-editor": "^0.50.0",
         "react-ace": "^11.0.1",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "16.0.1",
@@ -972,6 +997,7 @@
         "reactflow": "11.11.3",
         "ts-pattern": "^5.1.2",
         "use-debounce": "^10.0.0",
+        "zod": "^3.23.8",
         "zustand": "^4.5.2"
       },
       "peerDependencies": {
@@ -979,10 +1005,130 @@
         "react-dom": ">= 18"
       }
     },
+    "node_modules/@gorules/jdm-editor/node_modules/@reactflow/background": {
+      "version": "11.3.13",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.13.tgz",
+      "integrity": "sha512-hkvpVEhgvfTDyCvdlitw4ioKCYLaaiRXnuEG+1QM3Np+7N1DiWF1XOv5I8AFyNoJL07yXEkbECUTsHvkBvcG5A==",
+      "dependencies": {
+        "@reactflow/core": "11.11.3",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@gorules/jdm-editor/node_modules/@reactflow/controls": {
+      "version": "11.2.13",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.13.tgz",
+      "integrity": "sha512-3xgEg6ALIVkAQCS4NiBjb7ad8Cb3D8CtA7Vvl4Hf5Ar2PIVs6FOaeft9s2iDZGtsWP35ECDYId1rIFVhQL8r+A==",
+      "dependencies": {
+        "@reactflow/core": "11.11.3",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@gorules/jdm-editor/node_modules/@reactflow/core": {
+      "version": "11.11.3",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.3.tgz",
+      "integrity": "sha512-+adHdUa7fJSEM93fWfjQwyWXeI92a1eLKwWbIstoCakHpL8UjzwhEh6sn+mN2h/59MlVI7Ehr1iGTt3MsfcIFA==",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@gorules/jdm-editor/node_modules/@reactflow/minimap": {
+      "version": "11.7.13",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.13.tgz",
+      "integrity": "sha512-m2MvdiGSyOu44LEcERDEl1Aj6x//UQRWo3HEAejNU4HQTlJnYrSN8tgrYF8TxC1+c/9UdyzQY5VYgrTwW4QWdg==",
+      "dependencies": {
+        "@reactflow/core": "11.11.3",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@gorules/jdm-editor/node_modules/@reactflow/node-resizer": {
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.13.tgz",
+      "integrity": "sha512-X7ceQ2s3jFLgbkg03n2RYr4hm3jTVrzkW2W/8ANv/SZfuVmF8XJxlERuD8Eka5voKqLda0ywIZGAbw9GoHLfUQ==",
+      "dependencies": {
+        "@reactflow/core": "11.11.3",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@gorules/jdm-editor/node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.13.tgz",
+      "integrity": "sha512-aknvNICO10uWdthFSpgD6ctY/CTBeJUMV9co8T9Ilugr08Nb89IQ4uD0dPmr031ewMQxixtYIkw+sSDDzd2aaQ==",
+      "dependencies": {
+        "@reactflow/core": "11.11.3",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@gorules/jdm-editor/node_modules/reactflow": {
+      "version": "11.11.3",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.3.tgz",
+      "integrity": "sha512-wusd1Xpn1wgsSEv7UIa4NNraCwH9syBtubBy4xVNXg3b+CDKM+sFaF3hnMx0tr0et4km9urIDdNvwm34QiZong==",
+      "dependencies": {
+        "@reactflow/background": "11.3.13",
+        "@reactflow/controls": "11.2.13",
+        "@reactflow/core": "11.11.3",
+        "@reactflow/minimap": "11.7.13",
+        "@reactflow/node-resizer": "2.2.13",
+        "@reactflow/node-toolbar": "1.3.13"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@gorules/jdm-monorepo": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/bcgov/jdm-editor.git#d0a3a80c76a511fdfa76aa8f7cc4901ec3de49ae",
+      "engines": {
+        "pnpm": "~9"
+      }
+    },
     "node_modules/@gorules/lezer-zen": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@gorules/lezer-zen/-/lezer-zen-0.3.0.tgz",
-      "integrity": "sha512-n2zlZLge+h1Fzy501loX5yYKaM4ctbUaUJZmsM3cfG5IjgNwn1368/ZLPf/suWyBodK+YyL/Uy+lDv1IB49eYQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@gorules/lezer-zen/-/lezer-zen-0.4.0.tgz",
+      "integrity": "sha512-N75LNw8fhmzzVWhfzdvVjeeXFLvfaD+nEMpNedqUfJ1kuqtWL2qZGvbBuQgQwLHDWrmsrKopkuwf+/4E+h7Bcw==",
       "dependencies": {
         "@lezer/common": "^1.2.1",
         "@lezer/highlight": "^1.2.0",
@@ -1568,17 +1714,17 @@
       "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ=="
     },
     "node_modules/@lezer/highlight": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
-      "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.1.tgz",
-      "integrity": "sha512-CHsKq8DMKBf9b3yXPDIU4DbH+ZJd/sJdYOW2llbW/HudP5u0VS6Bfq1hLYfgU7uAYGFIyGGQIsSOXGPEErZiJw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -1940,11 +2086,11 @@
       "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA=="
     },
     "node_modules/@reactflow/background": {
-      "version": "11.3.13",
-      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.13.tgz",
-      "integrity": "sha512-hkvpVEhgvfTDyCvdlitw4ioKCYLaaiRXnuEG+1QM3Np+7N1DiWF1XOv5I8AFyNoJL07yXEkbECUTsHvkBvcG5A==",
+      "version": "11.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
       "dependencies": {
-        "@reactflow/core": "11.11.3",
+        "@reactflow/core": "11.11.4",
         "classcat": "^5.0.3",
         "zustand": "^4.4.1"
       },
@@ -1954,11 +2100,11 @@
       }
     },
     "node_modules/@reactflow/controls": {
-      "version": "11.2.13",
-      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.13.tgz",
-      "integrity": "sha512-3xgEg6ALIVkAQCS4NiBjb7ad8Cb3D8CtA7Vvl4Hf5Ar2PIVs6FOaeft9s2iDZGtsWP35ECDYId1rIFVhQL8r+A==",
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
       "dependencies": {
-        "@reactflow/core": "11.11.3",
+        "@reactflow/core": "11.11.4",
         "classcat": "^5.0.3",
         "zustand": "^4.4.1"
       },
@@ -1968,9 +2114,9 @@
       }
     },
     "node_modules/@reactflow/core": {
-      "version": "11.11.3",
-      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.3.tgz",
-      "integrity": "sha512-+adHdUa7fJSEM93fWfjQwyWXeI92a1eLKwWbIstoCakHpL8UjzwhEh6sn+mN2h/59MlVI7Ehr1iGTt3MsfcIFA==",
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
       "dependencies": {
         "@types/d3": "^7.4.0",
         "@types/d3-drag": "^3.0.1",
@@ -1988,11 +2134,11 @@
       }
     },
     "node_modules/@reactflow/minimap": {
-      "version": "11.7.13",
-      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.13.tgz",
-      "integrity": "sha512-m2MvdiGSyOu44LEcERDEl1Aj6x//UQRWo3HEAejNU4HQTlJnYrSN8tgrYF8TxC1+c/9UdyzQY5VYgrTwW4QWdg==",
+      "version": "11.7.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
       "dependencies": {
-        "@reactflow/core": "11.11.3",
+        "@reactflow/core": "11.11.4",
         "@types/d3-selection": "^3.0.3",
         "@types/d3-zoom": "^3.0.1",
         "classcat": "^5.0.3",
@@ -2006,11 +2152,11 @@
       }
     },
     "node_modules/@reactflow/node-resizer": {
-      "version": "2.2.13",
-      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.13.tgz",
-      "integrity": "sha512-X7ceQ2s3jFLgbkg03n2RYr4hm3jTVrzkW2W/8ANv/SZfuVmF8XJxlERuD8Eka5voKqLda0ywIZGAbw9GoHLfUQ==",
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
       "dependencies": {
-        "@reactflow/core": "11.11.3",
+        "@reactflow/core": "11.11.4",
         "classcat": "^5.0.4",
         "d3-drag": "^3.0.0",
         "d3-selection": "^3.0.0",
@@ -2022,11 +2168,11 @@
       }
     },
     "node_modules/@reactflow/node-toolbar": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.13.tgz",
-      "integrity": "sha512-aknvNICO10uWdthFSpgD6ctY/CTBeJUMV9co8T9Ilugr08Nb89IQ4uD0dPmr031ewMQxixtYIkw+sSDDzd2aaQ==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
       "dependencies": {
-        "@reactflow/core": "11.11.3",
+        "@reactflow/core": "11.11.4",
         "classcat": "^5.0.3",
         "zustand": "^4.4.1"
       },
@@ -2341,33 +2487,25 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -2694,9 +2832,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw=="
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA=="
     },
     "node_modules/@types/node": {
       "version": "20.11.20",
@@ -2904,9 +3042,9 @@
       "dev": true
     },
     "node_modules/ace-builds": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.35.0.tgz",
-      "integrity": "sha512-bwDKqjqNccC/MSujqnYTeAS5dIR8UmGLP0R90mvsJY0FRC8NUWBSTfj34+EIzo2NWc/gV8IZTqv4fXaiZJpCtA=="
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.2.tgz",
+      "integrity": "sha512-eqqfbGwx/GKjM/EnFu4QtQ+d2NNBu84MGgxoG8R5iyFpcVeQ4p9YlTL+ZzdEJqhdkASqoqOxCSNNGyB6lvMm+A=="
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -3232,9 +3370,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3416,9 +3552,9 @@
       "dev": true
     },
     "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/asynciterator.prototype": {
       "version": "1.0.0",
@@ -4178,9 +4314,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -4474,8 +4608,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -8031,9 +8163,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -8160,9 +8290,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.48.0.tgz",
-      "integrity": "sha512-goSDElNqFfw7iDHMg8WDATkfcyeLTNpBHQpO8incK6p5qZt5G/1j41X0xdGzpIkGojGXM+QiRQyLjnfDVvrpwA=="
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
+      "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -9568,16 +9698,16 @@
       }
     },
     "node_modules/reactflow": {
-      "version": "11.11.3",
-      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.3.tgz",
-      "integrity": "sha512-wusd1Xpn1wgsSEv7UIa4NNraCwH9syBtubBy4xVNXg3b+CDKM+sFaF3hnMx0tr0et4km9urIDdNvwm34QiZong==",
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
       "dependencies": {
-        "@reactflow/background": "11.3.13",
-        "@reactflow/controls": "11.2.13",
-        "@reactflow/core": "11.11.3",
-        "@reactflow/minimap": "11.7.13",
-        "@reactflow/node-resizer": "2.2.13",
-        "@reactflow/node-toolbar": "1.3.13"
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
       },
       "peerDependencies": {
         "react": ">=17",
@@ -10592,8 +10722,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10633,9 +10761,9 @@
       }
     },
     "node_modules/ts-pattern": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.2.0.tgz",
-      "integrity": "sha512-aGaSpOlDcns7ZoeG/OMftWyQG1KqPVhgplhJxNCvyIXqWrumM5uIoOSarw/hmmi/T1PnuQ/uD8NaFHvLpHicDg=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.3.1.tgz",
+      "integrity": "sha512-1RUMKa8jYQdNfmnK4jyzBK3/PS/tnjcZ1CW0v1vWDeYe5RBklc/nquw03MEoB66hVBm4BnlCfmOqDVxHyT1DpA=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -10913,20 +11041,20 @@
       }
     },
     "node_modules/use-debounce": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.0.tgz",
-      "integrity": "sha512-XRjvlvCB46bah9IBXVnq/ACP2lxqXyZj0D9hj4K5OzNroMDpTEBg8Anuh1/UfRTRs7pLhQ+RiNxxwZu9+MVl1A==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.3.tgz",
+      "integrity": "sha512-DxQSI9ZKso689WM1mjgGU3ozcxU1TJElBJ3X6S4SMzMNcm2lVH0AHmyXB+K7ewjz2BSUKJTDqTcwtSMRfB89dg==",
       "engines": {
         "node": ">= 16.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "react": "*"
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -10948,9 +11076,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -11378,8 +11504,6 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11449,12 +11573,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zustand": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.2.tgz",
-      "integrity": "sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
+      "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
       "dependencies": {
-        "use-sync-external-store": "1.2.0"
+        "use-sync-external-store": "1.2.2"
       },
       "engines": {
         "node": ">=12.7.0"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@ant-design/nextjs-registry": "^1.0.0",
-    "@gorules/jdm-editor": "https://gitpkg.vercel.app/bcgov/jdm-editor/packages/jdm-editor?feature/input-output-schema-support",
-    "@gorules/jdm-monorepo": "bcgov/jdm-editor#feature/input-output-schema-support",
+    "@gorules/jdm-editor": "https://gitpkg.vercel.app/bcgov/jdm-editor/packages/jdm-editor?master",
+    "@gorules/jdm-monorepo": "bcgov/jdm-editor",
     "@rjsf/core": "^5.17.1",
     "@rjsf/utils": "^5.17.1",
     "@rjsf/validator-ajv8": "^5.17.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@ant-design/nextjs-registry": "^1.0.0",
-    "@gorules/jdm-editor": "^1.9.0",
+    "@gorules/jdm-editor": "https://gitpkg.vercel.app/bcgov/jdm-editor/packages/jdm-editor?feature/input-output-schema-support",
+    "@gorules/jdm-monorepo": "bcgov/jdm-editor#feature/input-output-schema-support",
     "@rjsf/core": "^5.17.1",
     "@rjsf/utils": "^5.17.1",
     "@rjsf/validator-ajv8": "^5.17.1",
@@ -22,7 +23,8 @@
     "json5": "^2.2.3",
     "next": "14.1.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "reactflow": "^11.11.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.5",
@@ -36,6 +38,7 @@
     "eslint-config-next": "14.1.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
- [x] Added new custom input/output fields to request/response components (built as replacement)
- [x] Passing input/output field schemas from the request/response components to the rest of the JDM editor 
- [x] Added spinner to rule viewer when content not yet loaded
- [x] Added Klamm API proxy integration to get bre fields

NOTE: due to technical constraints, adding new custom input/output fields to request/response components required creating a new duplicate component. The duplicate components act the same way when used. It is not possible to alter the existing ones any other way without altering the underlying jdm library. This may be fixed via a custom fork of the jdm library if deemed necessary in the future