### PR TITLE
Update all uses of 'goRulesJSONFilename' to 'filepath'

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -55,7 +55,7 @@ export default function Admin() {
         } else if (
           initialRule._id !== rule._id ||
           initialRule.title !== rule.title ||
-          initialRule.goRulesJSONFilename !== rule.goRulesJSONFilename
+          initialRule.filepath !== rule.filepath
         ) {
           return { rule, action: ACTION_STATUS.UPDATE };
         }
@@ -112,9 +112,9 @@ export default function Admin() {
       width: "220px",
     },
     {
-      title: "GoRules JSON Filename",
-      dataIndex: "goRulesJSONFilename",
-      render: renderInputField("goRulesJSONFilename"),
+      title: "Filepath",
+      dataIndex: "filepath",
+      render: renderInputField("filepath"),
     },
     {
       dataIndex: "delete",

--- a/app/components/RuleHeader/RuleHeader.test.js
+++ b/app/components/RuleHeader/RuleHeader.test.js
@@ -19,7 +19,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 describe("RuleHeader - doneEditingTitle", () => {
-  const ruleInfoMock = { _id: "1", title: "Original Title", goRulesJSONFilename: "filename.json" };
+  const ruleInfoMock = { _id: "1", title: "Original Title", filepath: "filename.json" };
 
   it("updates title on success", async () => {
     api.updateRuleData.mockResolvedValue({}); // Mock success

--- a/app/components/RuleHeader/RuleHeader.tsx
+++ b/app/components/RuleHeader/RuleHeader.tsx
@@ -23,9 +23,9 @@ export default function RuleHeader({
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    const { title, goRulesJSONFilename } = ruleInfo;
-    setSavedTitle(title || goRulesJSONFilename);
-    setCurrTitle(title || goRulesJSONFilename);
+    const { title, filepath } = ruleInfo;
+    setSavedTitle(title || filepath);
+    setCurrTitle(title || filepath);
   }, [ruleInfo]);
 
   useEffect(() => {
@@ -100,7 +100,7 @@ export default function RuleHeader({
                 currTitle
               )}
             </h1>
-            <p className={styles.titleFilePath}>{ruleInfo.goRulesJSONFilename}</p>
+            <p className={styles.titleFilePath}>{ruleInfo.filepath}</p>
           </Flex>
           {isEditingTitle && (
             <button className={styles.editButton} onClick={isEditingTitle ? doneEditingTitle : startEditingTitle}>

--- a/app/components/RuleManager/RuleManager.tsx
+++ b/app/components/RuleManager/RuleManager.tsx
@@ -31,7 +31,7 @@ export default function RuleManager({
   editing = false,
   showAllScenarioTabs = true,
 }: RuleManagerProps) {
-  const { _id: ruleId, goRulesJSONFilename: jsonFile } = ruleInfo;
+  const { _id: ruleId, filepath: jsonFile } = ruleInfo;
   const createRuleMap = (array: any[] = [], preExistingContext?: Record<string, any>) => {
     return array.reduce(
       (acc, obj) => {

--- a/app/components/RuleViewerEditor/subcomponents/LinkRuleComponent.tsx
+++ b/app/components/RuleViewerEditor/subcomponents/LinkRuleComponent.tsx
@@ -16,7 +16,7 @@ interface LinkRuleComponent extends GraphNodeProps {
 export default function LinkRuleComponent({ specification, id, isSelected, name, isEditable }: LinkRuleComponent) {
   const { updateNode } = useDecisionGraphActions();
   const node = useDecisionGraphState((state) => (state.decisionGraph?.nodes || []).find((n) => n.id === id));
-  const goRulesJSONFilename = node?.content?.key;
+  const filepath = node?.content?.key;
 
   const [openRuleDrawer, setOpenRuleDrawer] = useState(false);
   const [ruleOptions, setRuleOptions] = useState<DefaultOptionType[]>([]);
@@ -30,9 +30,9 @@ export default function LinkRuleComponent({ specification, id, isSelected, name,
     const getRuleOptions = async () => {
       const ruleData = await getAllRuleData();
       setRuleOptions(
-        ruleData.map(({ title, goRulesJSONFilename }) => ({
-          label: title || goRulesJSONFilename,
-          value: goRulesJSONFilename,
+        ruleData.map(({ title, filepath }) => ({
+          label: title || filepath,
+          value: filepath,
         }))
       );
     };
@@ -42,10 +42,10 @@ export default function LinkRuleComponent({ specification, id, isSelected, name,
   }, [openRuleDrawer]);
 
   useEffect(() => {
-    if (goRulesJSONFilename) {
-      updateRuleContent(goRulesJSONFilename);
+    if (filepath) {
+      updateRuleContent(filepath);
     }
-  }, [goRulesJSONFilename]);
+  }, [filepath]);
 
   const showRuleDrawer = () => {
     setOpenRuleDrawer(true);
@@ -67,7 +67,7 @@ export default function LinkRuleComponent({ specification, id, isSelected, name,
   return (
     <GraphNode id={id} specification={specification} name={name} isSelected={isSelected}>
       <Button onClick={showRuleDrawer}>
-        {goRulesJSONFilename ? getShortFilenameOnly(goRulesJSONFilename) : "Add rule"}
+        {filepath ? getShortFilenameOnly(filepath) : "Add rule"}
         <EditOutlined />
       </Button>
       <Drawer title={name} onClose={closeRuleDrawer} open={openRuleDrawer} width="80%">
@@ -83,14 +83,14 @@ export default function LinkRuleComponent({ specification, id, isSelected, name,
                 }
                 options={ruleOptions}
                 onChange={onChangeSelection}
-                value={goRulesJSONFilename}
+                value={filepath}
                 className={styles.ruleSelect}
               />
               <Button onClick={closeRuleDrawer}>Done</Button>
             </Flex>
-            {goRulesJSONFilename && (
+            {filepath && (
               <RuleManager
-                ruleInfo={{ _id: id, goRulesJSONFilename }}
+                ruleInfo={{ _id: id, filepath }}
                 initialRuleContent={selectedRuleContent}
                 editing={false}
                 showAllScenarioTabs={false}

--- a/app/components/SavePublish/SavePublish.tsx
+++ b/app/components/SavePublish/SavePublish.tsx
@@ -16,7 +16,7 @@ interface SavePublishProps {
 }
 
 export default function SavePublish({ ruleInfo, ruleContent, setHasSaved }: SavePublishProps) {
-  const { _id: ruleId, goRulesJSONFilename: filePath, reviewBranch } = ruleInfo;
+  const { _id: ruleId, filepath: filePath, reviewBranch } = ruleInfo;
 
   const { message } = App.useApp();
   const [openNewReviewModal, setOpenNewReviewModal] = useState(false);

--- a/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
+++ b/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
@@ -67,7 +67,7 @@ export default function ScenarioGenerator({
     const newScenario: Scenario = {
       title: scenarioName,
       ruleID: ruleId,
-      goRulesJSONFilename: jsonFile,
+      filepath: jsonFile,
       variables,
       expectedResults,
     };

--- a/app/components/ScenariosManager/ScenarioResults/ScenarioResults.tsx
+++ b/app/components/ScenariosManager/ScenarioResults/ScenarioResults.tsx
@@ -280,9 +280,9 @@ export default function ScenarioResults({ scenarios, jsonFile, ruleContent }: Sc
     return resultStatus;
   };
 
-  const updateScenarioResults = async (goRulesJSONFilename: string) => {
+  const updateScenarioResults = async (filepath: string) => {
     try {
-      const results = await runDecisionsForScenarios(goRulesJSONFilename, ruleContent);
+      const results = await runDecisionsForScenarios(filepath, ruleContent);
       // Loop through object and check if data.result is an array
       for (const key in results) {
         if (Array.isArray(results[key].result)) {

--- a/app/hooks/getRuleDataForVersion.ts
+++ b/app/hooks/getRuleDataForVersion.ts
@@ -24,10 +24,10 @@ export default async function getRuleDataForVersion(ruleId: string, version?: st
         if (!ruleInfo.reviewBranch) {
           throw new Error("No branch in review");
         }
-        ruleContent = await getFileAsJsonIfAlreadyExists(ruleInfo.reviewBranch, ruleInfo.goRulesJSONFilename);
+        ruleContent = await getFileAsJsonIfAlreadyExists(ruleInfo.reviewBranch, ruleInfo.filepath);
         break;
       default:
-        ruleContent = await getDocument(ruleInfo.goRulesJSONFilename);
+        ruleContent = await getDocument(ruleInfo.filepath);
     }
   } catch (error) {
     console.error("Error fetching rule content:", error);
@@ -37,8 +37,8 @@ export default async function getRuleDataForVersion(ruleId: string, version?: st
 }
 
 async function getPublishedRuleContentOrDefault(ruleInfo: RuleInfo) {
-  if (ruleInfo.goRulesJSONFilename) {
-    return await getDocument(ruleInfo.goRulesJSONFilename);
+  if (ruleInfo.filepath) {
+    return await getDocument(ruleInfo.filepath);
   }
   return DEFAULT_RULE_CONTENT;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
     getRules();
   }, []);
 
-  const mappedRules = rules.map(({ _id, title, goRulesJSONFilename, reviewBranch, isPublished }) => {
+  const mappedRules = rules.map(({ _id, title, filepath, reviewBranch, isPublished }) => {
     const ruleLink = `/rule/${_id}`;
     const draftLink = `${ruleLink}?version=draft`;
     return {
@@ -33,7 +33,7 @@ export default function Home() {
       titleLink: (
         <b>
           <a href={isPublished ? ruleLink : draftLink} className={styles.mainLink}>
-            {title || goRulesJSONFilename}
+            {title || filepath}
           </a>
         </b>
       ),

--- a/app/rule/[ruleId]/embedded/page.tsx
+++ b/app/rule/[ruleId]/embedded/page.tsx
@@ -12,7 +12,7 @@ export default async function Rule({ params: { ruleId } }: { params: { ruleId: s
     return <h1>Rule not found</h1>;
   }
   // Get scenario information
-  const scenarios: Scenario[] = await getScenariosByFilename(ruleInfo.goRulesJSONFilename);
+  const scenarios: Scenario[] = await getScenariosByFilename(ruleInfo.filepath);
 
   return (
     <RuleManager

--- a/app/rule/[ruleId]/page.tsx
+++ b/app/rule/[ruleId]/page.tsx
@@ -5,7 +5,7 @@ import RuleManager from "@/app/components/RuleManager";
 import { Scenario } from "@/app/types/scenario";
 import getRuleDataForVersion from "@/app/hooks/getRuleDataForVersion";
 import { RULE_VERSION } from "@/app/constants/ruleVersion";
-import { GithubAuthProvider, GithubAuthContextType } from "@/app/components/GithubAuthProvider";
+import { GithubAuthProvider } from "@/app/components/GithubAuthProvider";
 import useGithubAuth from "@/app/hooks/useGithubAuth";
 
 export let metadata: Metadata;
@@ -36,7 +36,7 @@ export default async function Rule({
   metadata = { title: ruleInfo.title };
 
   // Get scenario information
-  const scenarios: Scenario[] = await getScenariosByFilename(ruleInfo.goRulesJSONFilename);
+  const scenarios: Scenario[] = await getScenariosByFilename(ruleInfo.filepath);
 
   return (
     <GithubAuthProvider authInfo={githubAuthInfo}>

--- a/app/rule/new/NewRule.tsx
+++ b/app/rule/new/NewRule.tsx
@@ -13,11 +13,11 @@ export default function NewRule() {
   const [ruleInfo, setRuleInfo] = useState<RuleInfo>({
     _id: "",
     title: "New rule",
-    goRulesJSONFilename: "",
+    filepath: "",
   });
 
   useEffect(() => {
-    setOpenNewRuleModal(!ruleInfo.goRulesJSONFilename);
+    setOpenNewRuleModal(!ruleInfo.filepath);
   }, [ruleInfo]);
 
   const createNewRule = async (newRuleInfo: Partial<RuleInfo>) => {
@@ -43,7 +43,7 @@ export default function NewRule() {
           </Form.Item>
           <Form.Item
             label="File path/name"
-            name="goRulesJSONFilename"
+            name="filepath"
             tooltip="example: my-rule.json or my-path/my-rule.json"
             rules={[
               {
@@ -72,9 +72,7 @@ export default function NewRule() {
         </Form>
       </Modal>
       <RuleHeader ruleInfo={ruleInfo} version={RULE_VERSION.draft} />
-      {ruleInfo.goRulesJSONFilename && (
-        <RuleManager ruleInfo={ruleInfo} initialRuleContent={DEFAULT_RULE_CONTENT} editing />
-      )}
+      {ruleInfo.filepath && <RuleManager ruleInfo={ruleInfo} initialRuleContent={DEFAULT_RULE_CONTENT} editing />}
     </>
   );
 }

--- a/app/types/ruleInfo.d.ts
+++ b/app/types/ruleInfo.d.ts
@@ -5,8 +5,9 @@ export interface RuleDraft {
 
 export interface RuleInfoBasic {
   _id: string;
+  name: string;
   title?: string;
-  goRulesJSONFilename: string;
+  filepath: string;
 }
 
 export interface RuleInfo extends RuleInfoBasic {

--- a/app/types/scenario.d.ts
+++ b/app/types/scenario.d.ts
@@ -2,7 +2,7 @@ export interface Scenario {
   _id?: string; //optional for create scenario as generated id
   title: string;
   ruleID: string;
-  goRulesJSONFilename: string;
+  filepath: string;
   variables: Variable[];
   expectedResults: any[];
 }

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -166,14 +166,14 @@ export const deleteRuleData = async (ruleId: string) => {
 
 /**
  * Retrieves a rule map from the API
- * @param goRulesJSONFilename The ID of the rule data to retrieve.
+ * @param filepath The ID of the rule data to retrieve.
  * @param ruleContent The rule decision graph to evaluate.
  * @returns The rule map.
  * @throws If an error occurs while retrieving the rule data.
  */
-export const getRuleMap = async (goRulesJSONFilename: string, ruleContent?: DecisionGraphType): Promise<RuleMap> => {
+export const getRuleMap = async (filepath: string, ruleContent?: DecisionGraphType): Promise<RuleMap> => {
   try {
-    const { data } = await axiosAPIInstance.post("/rulemap", { goRulesJSONFilename, ruleContent });
+    const { data } = await axiosAPIInstance.post("/rulemap", { filepath, ruleContent });
     return data;
   } catch (error) {
     console.error(`Error getting rule data: ${error}`);
@@ -217,13 +217,13 @@ export const generateSchemaFromRuleContent = async (ruleContent: DecisionGraphTy
 
 /**
  * Retrieves the scenarios for a rule from the API based on the provided filename
- * @param goRulesJSONFilename The name of the rule data to retrieve.
+ * @param filepath The name of the rule data to retrieve.
  * @returns The scenarios for the rule.
  * @throws If an error occurs while retrieving the rule data.
  */
-export const getScenariosByFilename = async (goRulesJSONFilename: string) => {
+export const getScenariosByFilename = async (filepath: string) => {
   try {
-    const { data } = await axiosAPIInstance.post("/scenario/by-filename/", { goRulesJSONFilename });
+    const { data } = await axiosAPIInstance.post("/scenario/by-filename/", { filepath });
     return data;
   } catch (error) {
     console.error(`Error posting output schema: ${error}`);
@@ -282,14 +282,14 @@ export const deleteScenario = async (scenarioId: string) => {
 
 /**
  * Runs all scenarios against a rule and exports the results as a CSV.
- * @param goRulesJSONFilename The filename of the rule to evaluate scenarios against.
+ * @param filepath The filename of the rule to evaluate scenarios against.
  * @param ruleContent The rule decision graph to evaluate.
  * @returns The CSV data containing the results of the scenario evaluations.
  * @throws If an error occurs while running the scenarios or generating the CSV.
  */
-export const runDecisionsForScenarios = async (goRulesJSONFilename: string, ruleContent?: DecisionGraphType) => {
+export const runDecisionsForScenarios = async (filepath: string, ruleContent?: DecisionGraphType) => {
   try {
-    const { data } = await axiosAPIInstance.post("/scenario/run-decisions", { goRulesJSONFilename, ruleContent });
+    const { data } = await axiosAPIInstance.post("/scenario/run-decisions", { filepath, ruleContent });
     return data;
   } catch (error) {
     console.error(`Error running scenarios: ${error}`);
@@ -299,27 +299,27 @@ export const runDecisionsForScenarios = async (goRulesJSONFilename: string, rule
 
 /**
  * Downloads a CSV file containing scenarios for a rule run.
- * @param goRulesJSONFilename The filename for the JSON rule.
+ * @param filepath The filename for the JSON rule.
  * @param ruleContent The rule decision graph to evaluate.
  * @returns The processed CSV content as a string.
  * @throws If an error occurs during file upload or processing.
  */
 export const getCSVForRuleRun = async (
-  goRulesJSONFilename: string,
+  filepath: string,
   ruleVersion: string,
   ruleContent?: DecisionGraphType
 ): Promise<string> => {
   try {
     const response = await axiosAPIInstance.post(
       "/scenario/evaluation",
-      { goRulesJSONFilename, ruleContent },
+      { filepath, ruleContent },
       {
         responseType: "blob",
         headers: { "Content-Type": "application/json" },
       }
     );
 
-    const filename = `${(ruleVersion + "_" + goRulesJSONFilename).replace(/\.json$/, ".csv")}`;
+    const filename = `${(ruleVersion + "_" + filepath).replace(/\.json$/, ".csv")}`;
     downloadFileBlob(response.data, "text/csv", filename);
 
     return "CSV downloaded successfully";
@@ -332,14 +332,14 @@ export const getCSVForRuleRun = async (
 /**
  * Uploads a CSV file containing scenarios and processes the scenarios against the specified rule.
  * @param file The file to be uploaded.
- * @param goRulesJSONFilename The filename for the JSON rule.
+ * @param filepath The filename for the JSON rule.
  * @param ruleContent The rule decision graph to evaluate.
  * @returns The processed CSV content as a string.
  * @throws If an error occurs during file upload or processing.
  */
 export const uploadCSVAndProcess = async (
   file: File,
-  goRulesJSONFilename: string,
+  filepath: string,
   ruleContent?: DecisionGraphType
 ): Promise<string> => {
   try {
@@ -347,7 +347,7 @@ export const uploadCSVAndProcess = async (
       `/scenario/evaluation/upload/`,
       {
         file,
-        goRulesJSONFilename,
+        filepath,
         ruleContent,
       },
       {
@@ -359,10 +359,7 @@ export const uploadCSVAndProcess = async (
     );
 
     const timestamp = new Date().toISOString().replace(/:/g, "-").replace(/\.\d+/, "");
-    const filename = `${goRulesJSONFilename.replace(".json", "")}_testing_${file.name.replace(
-      ".csv",
-      ""
-    )}_${timestamp}.csv`;
+    const filename = `${filepath.replace(".json", "")}_testing_${file.name.replace(".csv", "")}_${timestamp}.csv`;
     downloadFileBlob(response.data, "text/csv", filename);
 
     return "File processed successfully";


### PR DESCRIPTION
- [x] Update all uses of 'goRulesJSONFilename' to 'filepath' to improve current use and align with backend migration

Required backend PR: https://github.com/bcgov/brms-api/pull/37