### PR TITLE
Feature/search rules

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -74,8 +74,8 @@ export default function Admin() {
   };
 
   const deleteRule = async (index: number) => {
-    const deletionIndex =
-      ((tableParams?.pagination?.current || 1) - 1) * (tableParams?.pagination?.pageSize || PAGE_SIZE) + index;
+    const { current, pageSize } = tableParams?.pagination || {};
+    const deletionIndex = ((current || 1) - 1) * (pageSize || PAGE_SIZE) + index;
     const newRules = [...rules.slice(0, deletionIndex), ...rules.slice(deletionIndex + 1, rules.length)];
     setRules(newRules);
   };

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,7 +2,8 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Table, Input, Button, Flex } from "antd";
-import { ColumnsType } from "antd/es/table";
+import { ColumnsType, TablePaginationConfig } from "antd/es/table";
+import { FilterValue } from "antd/es/table/interface";
 import { HomeOutlined } from "@ant-design/icons";
 import { RuleInfo, RuleInfoBasic } from "../types/ruleInfo";
 import { getAllRuleData, postRuleData, updateRuleData, deleteRuleData } from "../utils/api";
@@ -15,23 +16,56 @@ enum ACTION_STATUS {
 
 const PAGE_SIZE = 15;
 
+interface TableParams {
+  pagination?: TablePaginationConfig;
+  searchTerm?: string;
+}
+
 export default function Admin() {
   const [isLoading, setIsLoading] = useState(true);
   const [initialRules, setInitialRules] = useState<RuleInfo[]>([]);
   const [rules, setRules] = useState<RuleInfo[]>([]);
-  const [currentPage, setCurrentPage] = useState(0);
+  const [tableParams, setTableParams] = useState<TableParams>({
+    pagination: {
+      current: 1,
+      pageSize: 15,
+      total: 0,
+    },
+    searchTerm: "",
+  });
 
   const getOrRefreshRuleList = async () => {
-    // Get rules that are already defined in the DB
-    const existingRules = await getAllRuleData();
-    setInitialRules(existingRules);
-    setRules(JSON.parse(JSON.stringify([...existingRules]))); // JSON.parse(JSON.stringify(data)) is a hacky way to deep copy the data - needed for comparison later
-    setIsLoading(false);
+    setIsLoading(true);
+    try {
+      const ruleData = await getAllRuleData({
+        page: tableParams.pagination?.current || 1,
+        pageSize: tableParams.pagination?.pageSize || 15,
+        searchTerm: tableParams.searchTerm || "",
+      });
+      const existingRules = ruleData?.data || [];
+      setInitialRules(existingRules);
+      setRules(JSON.parse(JSON.stringify([...existingRules])));
+      setTableParams({
+        ...tableParams,
+        pagination: {
+          ...tableParams.pagination,
+          total: ruleData?.total || 0,
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
-  useEffect(() => {
-    getOrRefreshRuleList();
-  }, []);
+  useEffect(
+    () => {
+      getOrRefreshRuleList();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(tableParams)]
+  );
 
   const updateRule = (e: React.ChangeEvent<HTMLInputElement>, index: number, property: keyof RuleInfoBasic) => {
     const newRules = [...rules];
@@ -40,7 +74,8 @@ export default function Admin() {
   };
 
   const deleteRule = async (index: number) => {
-    const deletionIndex = (currentPage - 1) * PAGE_SIZE + index;
+    const deletionIndex =
+      ((tableParams?.pagination?.current || 1) - 1) * (tableParams?.pagination?.pageSize || PAGE_SIZE) + index;
     const newRules = [...rules.slice(0, deletionIndex), ...rules.slice(deletionIndex + 1, rules.length)];
     setRules(newRules);
   };
@@ -65,11 +100,6 @@ export default function Admin() {
       .filter((initialRule) => !rules.find((rule) => rule._id === initialRule._id))
       .map((rule) => ({ rule, action: ACTION_STATUS.DELETE }));
     return [...updatedEntries, ...deletedEntries];
-  };
-
-  const updateCurrPage = (page: number, pageSize: number) => {
-    // Keep track of current page so we can delete via splice properly
-    setCurrentPage(page);
   };
 
   // Save all rule updates to the API/DB
@@ -136,6 +166,21 @@ export default function Admin() {
     },
   ];
 
+  const handleTableChange = (pagination: TablePaginationConfig, filters: Record<string, FilterValue | null>) => {
+    setTableParams((prevParams) => ({
+      pagination,
+      filters,
+      searchTerm: prevParams.searchTerm,
+    }));
+  };
+  const handleSearch = (value: string) => {
+    setTableParams({
+      ...tableParams,
+      searchTerm: value,
+      pagination: { ...tableParams.pagination, current: 1 },
+    });
+  };
+
   return (
     <>
       <Flex justify="space-between" align="center">
@@ -149,12 +194,16 @@ export default function Admin() {
           </Button>
         )}
       </Flex>
+      <Input.Search placeholder="Search rules..." onSearch={handleSearch} style={{ marginBottom: 16 }} allowClear />
+
       {isLoading ? (
         <p>Loading...</p>
       ) : (
         <Table
           columns={columns}
-          pagination={{ pageSize: PAGE_SIZE, onChange: updateCurrPage }}
+          pagination={tableParams.pagination}
+          onChange={handleTableChange}
+          loading={isLoading}
           dataSource={rules.map((rule, key) => ({ key, ...rule }))}
         />
       )}

--- a/app/components/InputOutputTable/InputOutputTable.tsx
+++ b/app/components/InputOutputTable/InputOutputTable.tsx
@@ -142,14 +142,14 @@ export default function InputOutputTable({
       const newData = Object.entries(rawData)
         .filter(([field]) => !PROPERTIES_TO_IGNORE.includes(field))
         .sort(([propertyA], [propertyB]) => propertyA.localeCompare(propertyB))
-        .map(([field, value], index) => ({
-          field: FieldStyler(
-            propertyRuleMap?.find((item) => item.field === field)?.name || field,
-            propertyRuleMap?.find((item) => item.field === field)?.description
-          ),
-          value: convertAndStyleValue(value, field, editable),
-          key: index,
-        }));
+        .map(([field, value], index) => {
+          const propertyRule = propertyRuleMap?.find((item) => item.field === field);
+          return {
+            field: FieldStyler(propertyRule?.name || field, propertyRule?.description),
+            value: convertAndStyleValue(value, field, editable),
+            key: index,
+          };
+        });
       setDataSource(newData);
       const newColumns = COLUMNS.filter((column) => showColumn(newData, column.dataIndex));
       setColumns(newColumns);

--- a/app/components/InputOutputTable/InputOutputTable.tsx
+++ b/app/components/InputOutputTable/InputOutputTable.tsx
@@ -4,6 +4,7 @@ import { MinusCircleOutlined } from "@ant-design/icons";
 import { RuleMap } from "@/app/types/rulemap";
 import styles from "./InputOutputTable.module.css";
 import { dollarFormat } from "@/app/utils/utils";
+import FieldStyler from "../InputStyler/subcomponents/FieldStyler";
 
 const COLUMNS = [
   {
@@ -142,7 +143,10 @@ export default function InputOutputTable({
         .filter(([field]) => !PROPERTIES_TO_IGNORE.includes(field))
         .sort(([propertyA], [propertyB]) => propertyA.localeCompare(propertyB))
         .map(([field, value], index) => ({
-          field: propertyRuleMap?.find((item) => item.field === field)?.name || field,
+          field: FieldStyler(
+            propertyRuleMap?.find((item) => item.field === field)?.name || field,
+            propertyRuleMap?.find((item) => item.field === field)?.description
+          ),
           value: convertAndStyleValue(value, field, editable),
           key: index,
         }));

--- a/app/components/InputStyler/subcomponents/FieldStyler.tsx
+++ b/app/components/InputStyler/subcomponents/FieldStyler.tsx
@@ -1,0 +1,24 @@
+import { Tooltip, Popover } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
+
+export default function FieldStyler(fieldName: string, description?: string) {
+  const popOverInformation = (
+    <Popover placement="top" content={description} title={fieldName} trigger={"click"}>
+      <span>
+        {" "}
+        <InfoCircleOutlined />
+      </span>
+    </Popover>
+  );
+  const helpDialog = "View Description";
+  return (
+    <label>
+      {fieldName}
+      {description && (
+        <Tooltip title={helpDialog} placement="top">
+          {popOverInformation}
+        </Tooltip>
+      )}
+    </label>
+  );
+}

--- a/app/components/InputStyler/subcomponents/InputComponents.tsx
+++ b/app/components/InputStyler/subcomponents/InputComponents.tsx
@@ -238,7 +238,20 @@ export const ReadOnlyBooleanDisplay = ({ show, value }: ReadOnlyProps) => {
 
 export const ReadOnlyStringDisplay = ({ show, value }: ReadOnlyProps) => {
   if (!show) return null;
-  return value.toString();
+  const stringList = value.split(",");
+  if (stringList.length > 1) {
+    return (
+      <>
+        {stringList.map((string: string, index: number) => (
+          <Tag color="blue" key={index}>
+            {string.trim()}
+          </Tag>
+        ))}
+      </>
+    );
+  }
+
+  return <Tag color="blue">{value}</Tag>;
 };
 
 export const ReadOnlyNumberDisplay = ({ show, value, field }: ReadOnlyNumberDisplayProps) => {

--- a/app/components/RuleManager/RuleManager.tsx
+++ b/app/components/RuleManager/RuleManager.tsx
@@ -9,6 +9,7 @@ import { RuleMap } from "@/app/types/rulemap";
 import { Scenario } from "@/app/types/scenario";
 import useLeaveScreenPopup from "@/app/hooks/useLeaveScreenPopup";
 import { DEFAULT_RULE_CONTENT } from "@/app/constants/defaultRuleContent";
+import { RULE_VERSION } from "@/app/constants/ruleVersion";
 import SavePublish from "../SavePublish";
 import ScenariosManager from "../ScenariosManager";
 import styles from "./RuleManager.module.css";
@@ -53,8 +54,8 @@ export default function RuleManager({
   const [simulationContext, setSimulationContext] = useState<Record<string, any>>();
   const [resultsOfSimulation, setResultsOfSimulation] = useState<Record<string, any> | null>();
   const { setHasUnsavedChanges } = useLeaveScreenPopup();
-  const canEditGraph = editing === "draft" || editing === true;
-  const canEditScenarios = editing === "draft" || editing === "inReview" || editing === true;
+  const canEditGraph = editing === RULE_VERSION.draft || editing === true;
+  const canEditScenarios = editing === RULE_VERSION.draft || editing === RULE_VERSION.inReview || editing === true;
 
   const updateRuleContent = (updatedRuleContent: DecisionGraphType) => {
     if (ruleContent !== updatedRuleContent) {

--- a/app/components/RuleManager/RuleManager.tsx
+++ b/app/components/RuleManager/RuleManager.tsx
@@ -54,7 +54,7 @@ export default function RuleManager({
   const [resultsOfSimulation, setResultsOfSimulation] = useState<Record<string, any> | null>();
   const { setHasUnsavedChanges } = useLeaveScreenPopup();
   const canEditGraph = editing === "draft" || editing === true;
-  const canEditScenarios = editing === "draft" || editing === "inreview" || editing === true;
+  const canEditScenarios = editing === "draft" || editing === "inReview" || editing === true;
 
   const updateRuleContent = (updatedRuleContent: DecisionGraphType) => {
     if (ruleContent !== updatedRuleContent) {

--- a/app/components/RuleViewerEditor/subcomponents/LinkRuleComponent.tsx
+++ b/app/components/RuleViewerEditor/subcomponents/LinkRuleComponent.tsx
@@ -30,7 +30,7 @@ export default function LinkRuleComponent({ specification, id, isSelected, name,
     const getRuleOptions = async () => {
       const ruleData = await getAllRuleData();
       setRuleOptions(
-        ruleData.map(({ title, filepath }) => ({
+        ruleData?.data.map(({ title, filepath }) => ({
           label: title || filepath,
           value: filepath,
         }))

--- a/app/components/ScenariosManager/IsolationTester/IsolationTester.tsx
+++ b/app/components/ScenariosManager/IsolationTester/IsolationTester.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Flex, Button, message, InputNumber, Collapse } from "antd";
+import { Flex, Button, message, InputNumber, Collapse, Spin } from "antd";
 import { Scenario } from "@/app/types/scenario";
 import { getCSVTests } from "@/app/utils/api";
 import { RuleMap } from "@/app/types/rulemap";
@@ -30,15 +30,19 @@ export default function IsolationTester({
   ruleVersion,
 }: IsolationTesterProps) {
   const [testScenarioCount, setTestScenarioCount] = useState<valueType | null>(10);
+  const [loading, setLoading] = useState(false);
 
   const handleCSVTests = async () => {
     const ruleName = ruleVersion === "draft" ? "Draft" : ruleVersion === "inreview" ? "In Review" : "Published";
     try {
+      setLoading(true);
       const csvContent = await getCSVTests(jsonFile, ruleName, ruleContent, simulationContext, testScenarioCount);
       message.success(`Scenario Tests: ${csvContent}`);
     } catch (error) {
       message.error("Error downloading scenarios.");
       console.error("Error:", error);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -102,9 +106,15 @@ export default function IsolationTester({
             </li>
             <li>
               Generate a CSV file with your created tests:{" "}
-              <Button onClick={handleCSVTests} size="large" type="primary">
-                Generate Tests
-              </Button>
+              {loading ? (
+                <Spin tip="Generating test scenarios..." className="spinner">
+                  <div className="content" />
+                </Spin>
+              ) : (
+                <Button onClick={handleCSVTests} size="large" type="primary">
+                  Generate Tests
+                </Button>
+              )}
             </li>
           </ol>
         </Flex>

--- a/app/components/ScenariosManager/IsolationTester/IsolationTester.tsx
+++ b/app/components/ScenariosManager/IsolationTester/IsolationTester.tsx
@@ -16,7 +16,6 @@ interface IsolationTesterProps {
   jsonFile: string;
   rulemap: RuleMap;
   ruleContent?: DecisionGraphType;
-  ruleVersion?: string | boolean;
 }
 
 export default function IsolationTester({
@@ -27,16 +26,14 @@ export default function IsolationTester({
   jsonFile,
   rulemap,
   ruleContent,
-  ruleVersion,
 }: IsolationTesterProps) {
   const [testScenarioCount, setTestScenarioCount] = useState<valueType | null>(10);
   const [loading, setLoading] = useState(false);
 
   const handleCSVTests = async () => {
-    const ruleName = ruleVersion === "draft" ? "Draft" : ruleVersion === "inreview" ? "In Review" : "Published";
     try {
       setLoading(true);
-      const csvContent = await getCSVTests(jsonFile, ruleName, ruleContent, simulationContext, testScenarioCount);
+      const csvContent = await getCSVTests(jsonFile, ruleContent, simulationContext, testScenarioCount);
       message.success(`Scenario Tests: ${csvContent}`);
     } catch (error) {
       message.error("Error downloading scenarios.");

--- a/app/components/ScenariosManager/ScenarioCSV/ScenarioCSV.tsx
+++ b/app/components/ScenariosManager/ScenarioCSV/ScenarioCSV.tsx
@@ -8,10 +8,9 @@ import { uploadCSVAndProcess, getCSVForRuleRun } from "@/app/utils/api";
 interface ScenarioCSVProps {
   jsonFile: string;
   ruleContent?: DecisionGraphType;
-  ruleVersion?: string | boolean;
 }
 
-export default function ScenarioCSV({ jsonFile, ruleContent, ruleVersion = "" }: ScenarioCSVProps) {
+export default function ScenarioCSV({ jsonFile, ruleContent }: ScenarioCSVProps) {
   const [file, setFile] = useState<File | null>(null);
   const [uploadedFile, setUploadedFile] = useState(false);
 
@@ -30,9 +29,8 @@ export default function ScenarioCSV({ jsonFile, ruleContent, ruleVersion = "" }:
   };
 
   const handleDownloadScenarios = async () => {
-    const ruleName = ruleVersion === "draft" ? "Draft" : ruleVersion === "inreview" ? "In Review" : "Published";
     try {
-      const csvContent = await getCSVForRuleRun(jsonFile, ruleName, ruleContent);
+      const csvContent = await getCSVForRuleRun(jsonFile, ruleContent);
       message.success(`Scenario Testing Template: ${csvContent}`);
     } catch (error) {
       message.error("Error downloading scenarios.");

--- a/app/components/ScenariosManager/ScenarioFormatter/ScenarioFormatter.tsx
+++ b/app/components/ScenariosManager/ScenarioFormatter/ScenarioFormatter.tsx
@@ -5,6 +5,7 @@ import styles from "./ScenarioFormatter.module.css";
 import { RuleMap } from "@/app/types/rulemap";
 import InputStyler from "../../InputStyler/InputStyler";
 import { parseSchemaTemplate } from "../../InputStyler/InputStyler";
+import FieldStyler from "../../InputStyler/subcomponents/FieldStyler";
 
 const COLUMNS = [
   {
@@ -62,10 +63,13 @@ export default function ScenarioFormatter({ title, rawData, setRawData, scenario
         .filter(([field]) => !PROPERTIES_TO_IGNORE.includes(field))
         .sort(([propertyA], [propertyB]) => propertyA.localeCompare(propertyB))
         .map(([field, value], index) => ({
-          field:
+          field: FieldStyler(
             propertyRuleMap?.find((item) => item.field === field)?.name ||
-            parseSchemaTemplate(field)?.arrayName ||
-            field,
+              parseSchemaTemplate(field)?.arrayName ||
+              field,
+            propertyRuleMap?.find((item) => item.field === field)?.description
+          ),
+
           value: InputStyler(
             value,
             field,

--- a/app/components/ScenariosManager/ScenariosManager.tsx
+++ b/app/components/ScenariosManager/ScenariosManager.tsx
@@ -121,7 +121,7 @@ export default function ScenariosManager({
 
   const csvTab = (
     <Flex gap="small">
-      <ScenarioCSV jsonFile={jsonFile} ruleContent={ruleContent} ruleVersion={isEditing} />
+      <ScenarioCSV jsonFile={jsonFile} ruleContent={ruleContent} />
     </Flex>
   );
 
@@ -135,7 +135,6 @@ export default function ScenariosManager({
         jsonFile={jsonFile}
         rulemap={rulemap}
         ruleContent={ruleContent}
-        ruleVersion={isEditing}
       />
       <Button onClick={handleReset} size="large" type="primary">
         Reset ↻

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -83,9 +83,13 @@ export default function Home() {
 
   const formatFilePathTags = (filepath: string) => {
     const parts = filepath.split("/");
-    return parts.map((part, index) => (
-      <React.Fragment key={index}>{index < parts.length - 1 && <Tag color="blue">{part}</Tag>}</React.Fragment>
-    ));
+    return (
+      <Flex gap="small" align="center" wrap={true}>
+        {parts.map((part, index) => (
+          <React.Fragment key={index}>{index < parts.length - 1 && <Tag color="blue">{part}</Tag>}</React.Fragment>
+        ))}
+      </Flex>
+    );
   };
 
   const columns: TableColumnsType<RuleInfo> = [
@@ -114,12 +118,15 @@ export default function Home() {
       filteredValue: tableParams.filters?.filepath || null,
       filterSearch: true,
       sorter: true,
+      width: "25%",
+      responsive: ["lg" as Breakpoint],
       render: (_, record) => <span>{formatFilePathTags(record.filepath)}</span>,
     },
     {
       title: "Versions",
       key: "versions",
       responsive: ["md" as Breakpoint],
+      width: "auto",
       render: (_, record) => {
         const ruleLink = `/rule/${record._id}`;
         const draftLink = `${ruleLink}?version=draft`;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -106,6 +106,7 @@ export default function Home() {
       key: "filepath",
       filters: categories,
       filteredValue: tableParams.filters?.filepath || null,
+      filterSearch: true,
       sorter: true,
       render: (_, record) => <span>{formatFilePathTags(record.filepath)}</span>,
     },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { Button, Flex, Spin, Table, Input, Tag } from "antd";
 import type { Breakpoint, TablePaginationConfig, TableColumnsType } from "antd";
@@ -34,7 +34,6 @@ export default function Home() {
   const fetchData = async () => {
     setLoading(true);
     try {
-      // Update this to match your API structure
       const response = await getAllRuleData({
         page: tableParams.pagination?.current || 1,
         pageSize: tableParams.pagination?.pageSize,
@@ -45,12 +44,12 @@ export default function Home() {
       });
 
       setRules(response.data);
-      setCategories(response.categories.map((category: string) => ({ text: category, value: category })));
+      setCategories(response.categories);
       setTableParams({
         ...tableParams,
         pagination: {
           ...tableParams.pagination,
-          total: response.total, // Assuming your API returns the total count
+          total: response.total,
         },
       });
     } catch (error) {
@@ -173,16 +172,24 @@ export default function Home() {
     filters: Record<string, FilterValue | null>,
     sorter: SorterResult<RuleInfo> | SorterResult<RuleInfo>[]
   ) => {
-    console.log(pagination, "this is pagination");
-    console.log(filters, "this is filters");
-    console.log(sorter, "this is sorter");
-    setTableParams({
+    setTableParams((prevParams) => ({
       pagination,
       filters,
+      searchTerm: prevParams.searchTerm,
       ...(!Array.isArray(sorter) && {
         sortField: sorter.field as string,
         sortOrder: sorter.order ? sorter.order : undefined,
       }),
+    }));
+  };
+
+  const clearAll = () => {
+    setTableParams({
+      pagination: { current: 1, pageSize: 15, total: 0 },
+      filters: {},
+      searchTerm: "",
+      sortField: "",
+      sortOrder: undefined,
     });
   };
 
@@ -199,7 +206,10 @@ export default function Home() {
           </Link>
         </Flex>
       </Flex>
-      <Input.Search placeholder="Search rules..." onSearch={handleSearch} style={{ marginBottom: 16 }} allowClear />
+      <Flex gap="small">
+        <Input.Search placeholder="Search rules..." onSearch={handleSearch} style={{ marginBottom: 16 }} allowClear />
+        <Button onClick={clearAll}>Reset Filters ↻</Button>
+      </Flex>
       {loading ? (
         <Spin tip="Loading rules..." className="spinner">
           <div className="content" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, Fragment } from "react";
 import Link from "next/link";
-import { Button, Flex, Spin, Table } from "antd";
-import type { Breakpoint } from "antd";
+import { Button, Flex, Spin, Table, Input, Tag } from "antd";
+import type { Breakpoint, TablePaginationConfig, TableColumnsType } from "antd";
+import type { FilterValue, SorterResult } from "antd/es/table/interface";
 import { EyeOutlined, EditOutlined, CheckCircleOutlined, DownSquareOutlined } from "@ant-design/icons";
 import { RuleInfo } from "./types/ruleInfo";
 import { getAllRuleData } from "./utils/api";
@@ -11,6 +12,12 @@ import styles from "./styles/home.module.css";
 export default function Home() {
   const [rules, setRules] = useState<RuleInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [filteredInfo, setFilteredInfo] = useState<Record<string, FilterValue | null>>({});
+  const [pagination, setPagination] = useState<TablePaginationConfig>({
+    current: 1,
+    pageSize: 15,
+  });
 
   useEffect(() => {
     const getRules = async () => {
@@ -25,74 +32,154 @@ export default function Home() {
     getRules();
   }, []);
 
-  const mappedRules = rules.map(({ _id, title, filepath, reviewBranch, isPublished }) => {
-    const ruleLink = `/rule/${_id}`;
-    const draftLink = `${ruleLink}?version=draft`;
-    return {
-      key: _id,
-      titleLink: (
-        <b>
-          <a href={isPublished ? ruleLink : draftLink} className={styles.mainLink}>
-            {title || filepath}
-          </a>
-        </b>
-      ),
-      versions: (
-        <Flex gap="small" justify="end">
-          <Button
-            href={draftLink}
-            icon={<EditOutlined />}
-            type="dashed"
-            size="small"
-            danger
-            className={styles.draftBtn}
-          >
-            Draft
-          </Button>
-          {reviewBranch && (
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
+    setPagination((prev) => ({ ...prev, current: 1 }));
+  };
+
+  const formatFilePathTags = (filepath: string) => {
+    const parts = filepath.split("/");
+    return parts.map((part, index) => (
+      <Fragment key={index}>{index < parts.length - 1 && <Tag color="blue">{part}</Tag>}</Fragment>
+    ));
+  };
+
+  // Generate filters for filepaths based on the full filepath of each rule
+  const getFilepathFilters = useMemo(() => {
+    const directories = new Set<string>();
+
+    rules.forEach((rule) => {
+      const parts = rule.filepath.split("/");
+      let currentPath = "";
+
+      parts.forEach((part, index) => {
+        if (index < parts.length - 1) {
+          currentPath += (currentPath ? "/" : "") + part;
+          directories.add(currentPath);
+        }
+      });
+    });
+
+    return Array.from(directories).map((path) => ({
+      text: path.split("/").pop() || "",
+      value: path,
+    }));
+  }, [rules]);
+
+  // Filter rules based on search terms and filepath filters
+  const filteredRules = useMemo(() => {
+    let result = rules;
+    if (searchTerm) {
+      result = result.filter(
+        (rule) =>
+          rule?.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          rule.filepath.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+    }
+    if (filteredInfo.filepath) {
+      const filepathFilters = filteredInfo.filepath as string[];
+      result = result.filter((rule) => filepathFilters.some((path) => rule.filepath.startsWith(path)));
+    }
+
+    return result;
+  }, [rules, searchTerm, filteredInfo]);
+
+  const columns: TableColumnsType<RuleInfo> = [
+    {
+      title: "Rule",
+      dataIndex: "title",
+      key: "title",
+      sorter: (a, b) => (a.title || "").localeCompare(b.title || ""),
+      render: (_, record) => {
+        const ruleLink = `/rule/${record._id}`;
+        const draftLink = `${ruleLink}?version=draft`;
+        return (
+          <b>
+            <a href={record.isPublished ? ruleLink : draftLink} className={styles.mainLink}>
+              {record.title || record.filepath}
+            </a>
+          </b>
+        );
+      },
+    },
+    {
+      title: "Categories",
+      dataIndex: "filepath",
+      key: "filepath",
+      filters: getFilepathFilters,
+      filteredValue: filteredInfo.filepath || null,
+      onFilter: (value, record) => record.filepath.startsWith(value as string),
+      filterMode: "tree",
+      filterSearch: true,
+      sorter: (a, b) => a.filepath.localeCompare(b.filepath),
+      render: (_, record) => <span>{formatFilePathTags(record.filepath)}</span>,
+    },
+    {
+      title: "Versions",
+      key: "versions",
+      responsive: ["md" as Breakpoint],
+      render: (_, record) => {
+        const ruleLink = `/rule/${record._id}`;
+        const draftLink = `${ruleLink}?version=draft`;
+        return (
+          <Flex gap="small" justify="end">
             <Button
-              href={`${ruleLink}?version=inReview`}
-              icon={<EyeOutlined />}
+              href={draftLink}
+              icon={<EditOutlined />}
               type="dashed"
               size="small"
-              className={styles.inReviewBtn}
+              danger
+              className={styles.draftBtn}
             >
-              In Review
+              Draft
             </Button>
-          )}
-          {isPublished && (
-            <>
+            {record.reviewBranch && (
               <Button
-                href={ruleLink}
-                icon={<CheckCircleOutlined />}
+                href={`${ruleLink}?version=inReview`}
+                icon={<EyeOutlined />}
                 type="dashed"
                 size="small"
-                className={styles.publishedBtn}
+                className={styles.inReviewBtn}
               >
-                Published
+                In Review
               </Button>
-              <Button
-                href={`${ruleLink}/embedded`}
-                icon={<DownSquareOutlined />}
-                type="dashed"
-                size="small"
-                className={styles.embeddedBtn}
-              >
-                Embeddable
-              </Button>
-            </>
-          )}
-        </Flex>
-      ),
-    };
-  });
-
-  const columns = [
-    {
-      dataIndex: "titleLink",
+            )}
+            {record.isPublished && (
+              <>
+                <Button
+                  href={ruleLink}
+                  icon={<CheckCircleOutlined />}
+                  type="dashed"
+                  size="small"
+                  className={styles.publishedBtn}
+                >
+                  Published
+                </Button>
+                <Button
+                  href={`${ruleLink}/embedded`}
+                  icon={<DownSquareOutlined />}
+                  type="dashed"
+                  size="small"
+                  className={styles.embeddedBtn}
+                >
+                  Embeddable
+                </Button>
+              </>
+            )}
+          </Flex>
+        );
+      },
     },
-    { dataIndex: "versions", responsive: ["md" as Breakpoint] },
   ];
+
+  const handleTableChange = (
+    newPagination: TablePaginationConfig,
+    filters: Record<string, FilterValue | null>,
+    sorter: SorterResult<RuleInfo> | SorterResult<RuleInfo>[]
+  ) => {
+    setPagination(newPagination);
+    setFilteredInfo(filters);
+  };
 
   return (
     <>
@@ -107,12 +194,23 @@ export default function Home() {
           </Link>
         </Flex>
       </Flex>
+      <Input.Search placeholder="Search rules..." onChange={handleSearch} style={{ marginBottom: 16 }} allowClear />
       {isLoading ? (
         <Spin tip="Loading rules..." className="spinner">
           <div className="content" />
         </Spin>
       ) : (
-        <Table columns={columns} dataSource={mappedRules} showHeader={false} pagination={{ pageSize: 15 }} />
+        <Table
+          columns={columns}
+          dataSource={filteredRules}
+          pagination={{
+            ...pagination,
+            total: filteredRules.length,
+            showSizeChanger: true,
+          }}
+          onChange={handleTableChange}
+          rowKey="_id"
+        />
       )}
     </>
   );

--- a/app/rule/[ruleId]/page.tsx
+++ b/app/rule/[ruleId]/page.tsx
@@ -8,15 +8,24 @@ import { RULE_VERSION } from "@/app/constants/ruleVersion";
 import { GithubAuthProvider } from "@/app/components/GithubAuthProvider";
 import useGithubAuth from "@/app/hooks/useGithubAuth";
 
-export let metadata: Metadata;
-
-export default async function Rule({
-  params: { ruleId },
-  searchParams,
-}: {
+type Props = {
   params: { ruleId: string };
   searchParams: { version?: string };
-}) {
+};
+
+// Update page title with rule name
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
+  const { ruleId } = params;
+  const { version } = searchParams;
+
+  const { ruleInfo } = await getRuleDataForVersion(ruleId, version);
+
+  return {
+    title: ruleInfo.title,
+  };
+}
+
+export default async function Rule({ params: { ruleId }, searchParams }: Props) {
   // Get version of rule to use
   const { version } = searchParams;
 
@@ -31,9 +40,6 @@ export default async function Rule({
   if (!ruleInfo._id || !ruleContent) {
     return <h1>Rule not found</h1>;
   }
-
-  // Update page title with rule name
-  metadata = { title: ruleInfo.title };
 
   // Get scenario information
   const scenarios: Scenario[] = await getScenariosByFilename(ruleInfo.filepath);

--- a/app/types/ruleInfo.d.ts
+++ b/app/types/ruleInfo.d.ts
@@ -15,3 +15,9 @@ export interface RuleInfo extends RuleInfoBasic {
   reviewBranch?: string;
   isPublished?: boolean;
 }
+
+export interface RuleDataResponse {
+  data: RuleInfo[];
+  total: number;
+  categories: Array<string>;
+}

--- a/app/types/ruleInfo.d.ts
+++ b/app/types/ruleInfo.d.ts
@@ -16,8 +16,13 @@ export interface RuleInfo extends RuleInfoBasic {
   isPublished?: boolean;
 }
 
+export interface CategoryObject {
+  text: string;
+  value: string;
+}
+
 export interface RuleDataResponse {
   data: RuleInfo[];
   total: number;
-  categories: Array<string>;
+  categories: Array<CategoryObject>;
 }

--- a/app/types/rulequery.d.ts
+++ b/app/types/rulequery.d.ts
@@ -1,0 +1,10 @@
+import { FilterValue } from "antd/es/table/interface";
+
+export interface RuleQuery {
+  page?: number;
+  pageSize?: number;
+  sortField?: string;
+  sortOrder?: string;
+  filters?: Record<string, FilterValue, null> | undefined;
+  searchTerm?: string;
+}

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -52,7 +52,7 @@ export const getRuleDraft = async (ruleId: string): Promise<RuleDraft> => {
  * @returns The rule data list.
  * @throws If an error occurs while fetching the rule data.
  */
-export const getAllRuleData = async (params: RuleQuery): Promise<RuleDataResponse> => {
+export const getAllRuleData = async (params?: RuleQuery): Promise<RuleDataResponse> => {
   try {
     const { data } = await axiosAPIInstance.get<RuleDataResponse>("/ruleData/list", { params });
     return data;
@@ -302,6 +302,7 @@ export const runDecisionsForScenarios = async (filepath: string, ruleContent?: D
 /**
  * Downloads a CSV file containing scenarios for a rule run.
  * @param filepath The filename for the JSON rule.
+ * @param ruleVersion The version of the rule to run.
  * @param ruleContent The rule decision graph to evaluate.
  * @returns The processed CSV content as a string.
  * @throws If an error occurs during file upload or processing.
@@ -321,7 +322,7 @@ export const getCSVForRuleRun = async (
       }
     );
 
-    const filename = `${(ruleVersion + "_" + filepath).replace(/\.json$/, ".csv")}`;
+    const filename = `${filepath.replace(/\.json$/, ".csv")}`;
     downloadFileBlob(response.data, "text/csv", filename);
 
     return "CSV downloaded successfully";
@@ -407,8 +408,9 @@ export const getBREFieldFromName = async (fieldName: string): Promise<KlammBREFi
 /**
  * Generate CSV Tests for scenarios
  * @param filepath The filename for the JSON rule.
- * @param filepath The filename for the JSON rule.
  * @param ruleContent The rule decision graph to evaluate.
+ * @param simulationContext The simulation context to use for the tests.
+ * @param testScenarioCount The number of scenarios to generate.
  * @returns The processed CSV content as a string.
  * @throws If an error occurs during file upload or processing.
  */

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -302,16 +302,11 @@ export const runDecisionsForScenarios = async (filepath: string, ruleContent?: D
 /**
  * Downloads a CSV file containing scenarios for a rule run.
  * @param filepath The filename for the JSON rule.
- * @param ruleVersion The version of the rule to run.
  * @param ruleContent The rule decision graph to evaluate.
  * @returns The processed CSV content as a string.
  * @throws If an error occurs during file upload or processing.
  */
-export const getCSVForRuleRun = async (
-  filepath: string,
-  ruleVersion: string,
-  ruleContent?: DecisionGraphType
-): Promise<string> => {
+export const getCSVForRuleRun = async (filepath: string, ruleContent?: DecisionGraphType): Promise<string> => {
   try {
     const response = await axiosAPIInstance.post(
       "/scenario/evaluation",
@@ -417,7 +412,6 @@ export const getBREFieldFromName = async (fieldName: string): Promise<KlammBREFi
 
 export const getCSVTests = async (
   filepath: string,
-  ruleVersion: string,
   ruleContent?: DecisionGraphType,
   simulationContext?: Record<string, any>,
   testScenarioCount?: valueType | number | null

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -1,10 +1,11 @@
 import { DecisionGraphType } from "@gorules/jdm-editor";
 import axios from "axios";
-import { RuleDraft, RuleInfo } from "../types/ruleInfo";
+import { RuleDataResponse, RuleDraft, RuleInfo } from "../types/ruleInfo";
 import { RuleMap } from "../types/rulemap";
 import { KlammBREField } from "../types/klamm";
 import { downloadFileBlob, generateDescriptiveName, getShortFilenameOnly } from "./utils";
 import { valueType } from "antd/es/statistic/utils";
+import { RuleQuery } from "../types/rulequery";
 
 const axiosAPIInstance = axios.create({
   // For server side calls, need full URL, otherwise can just use /api
@@ -51,9 +52,9 @@ export const getRuleDraft = async (ruleId: string): Promise<RuleDraft> => {
  * @returns The rule data list.
  * @throws If an error occurs while fetching the rule data.
  */
-export const getAllRuleData = async (): Promise<RuleInfo[]> => {
+export const getAllRuleData = async (params: RuleQuery): Promise<RuleDataResponse> => {
   try {
-    const { data } = await axiosAPIInstance.get("/ruleData/list");
+    const { data } = await axiosAPIInstance.get<RuleDataResponse>("/ruleData/list", { params });
     return data;
   } catch (error) {
     console.error(`Error fetching rule data: ${error}`);


### PR DESCRIPTION
- [x] Update rules list to server-side pagination
- [x] Add rules list search, filtering by category, and updated pagination handling
- [x] Add search and pagination to admin page as well
- [x] Add a 'Field Styler' component to handle custom styling of scenario field names. Add a 'Tooltip' with hover and click to provide full descriptive information that doesn't disappear on scroll. Also update string display to correctly handle comma separated lists as individual tags in simulation viewer.
- [x] fix case error in rulemanager so scenarios can be properly edited in review status
- [x] Add loading display to prevent double press of isolation test generation.
- [x] Fix metadata load on original page load.

- [x] Added 'Sync with Klamm' button. Not intended to be permanent, but found this useful during my testing to re-sync klamm properties without having to delete and re-add. If this behaviour is desired, this could be refactored for reduced code repetition.