### PR TITLE
Feature/validation errors

### DIFF
--- a/app/components/RuleManager/RuleManager.tsx
+++ b/app/components/RuleManager/RuleManager.tsx
@@ -103,6 +103,7 @@ export default function RuleManager({
     if (runContext) {
       console.info("Simulate:", runContext);
       try {
+        message.destroy();
         const data = await postDecision(ruleContent, runContext);
         console.info("Simulation Results:", data, data?.result);
         // Check if data.result is an array and throw error as object is required
@@ -114,7 +115,7 @@ export default function RuleManager({
         // Set the results of the simulation
         setResultsOfSimulation(data?.result);
       } catch (e: any) {
-        message.error("Error during simulation run: " + e);
+        message.error("Error during simulation run: " + e, 10);
         console.error("Error during simulation run:", e);
       }
     } else {

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -112,8 +112,14 @@ export const postDecision = async (ruleContent: DecisionGraphType, context: unkn
     });
     return data;
   } catch (error) {
-    console.error(`Error simulating decision: ${error}`);
-    throw error;
+    if (axios.isAxiosError(error) && error.response) {
+      const errorMessage = error.response.data.message;
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    } else {
+      console.error(`Error simulating decision: ${error}`);
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
- [x] Updated error handling to show the error details for an extended time when simulating, and how to handle validation errors.
- [x] Updated admin page to fix previous bug for deletion and updates introduced in https://github.com/bcgov/brms-simulator-frontend/pull/38. Users can now only reset the draft version currently on file for any rules that are in Github - bringing the draft back in line with the current 'Published' version at any time. Users are directed to the rules repo to delete rules otherwise. If a rule only exists as a draft, it is able to be deleted.