### PR TITLE
GitHub saving scenarios

### DIFF
--- a/app/components/RuleManager/RuleManager.tsx
+++ b/app/components/RuleManager/RuleManager.tsx
@@ -200,6 +200,9 @@ export default function RuleManager({
           simulationContext={simulationContext}
           runSimulation={runSimulation}
           resultsOfSimulation={resultsOfSimulation}
+          branchName={ruleInfo.reviewBranch}
+          pathName={ruleInfo.filepath}
+          isInReviewMode={editing === RULE_VERSION.inReview}
         />
       )}
     </Flex>

--- a/app/components/RuleManager/RuleManager.tsx
+++ b/app/components/RuleManager/RuleManager.tsx
@@ -23,14 +23,14 @@ const RuleViewerEditor = dynamic(() => import("../RuleViewerEditor"), { ssr: fal
 interface RuleManagerProps {
   ruleInfo: RuleInfo;
   initialRuleContent?: DecisionGraphType;
-  editing?: string | boolean;
+  version: RULE_VERSION | boolean;
   showAllScenarioTabs?: boolean;
 }
 
 export default function RuleManager({
   ruleInfo,
   initialRuleContent = DEFAULT_RULE_CONTENT,
-  editing = false,
+  version,
   showAllScenarioTabs = true,
 }: RuleManagerProps) {
   const { _id: ruleId, filepath: jsonFile } = ruleInfo;
@@ -56,8 +56,8 @@ export default function RuleManager({
   const [simulationContext, setSimulationContext] = useState<Record<string, any>>();
   const [resultsOfSimulation, setResultsOfSimulation] = useState<Record<string, any> | null>();
   const { setHasUnsavedChanges } = useLeaveScreenPopup();
-  const canEditGraph = editing === RULE_VERSION.draft || editing === true;
-  const canEditScenarios = editing === RULE_VERSION.draft || editing === RULE_VERSION.inReview || editing === true;
+  const canEditGraph = version === RULE_VERSION.draft || version === true;
+  const canEditScenarios = version === RULE_VERSION.draft || version === RULE_VERSION.inReview || version === true;
 
   const updateRuleContent = (updatedRuleContent: DecisionGraphType) => {
     if (ruleContent !== updatedRuleContent) {
@@ -146,21 +146,21 @@ export default function RuleManager({
     );
   }
 
-  const versionColour = getVersionColor(editing.toString());
+  const versionColour = getVersionColor(version.toString());
 
   return (
     <Flex gap="middle" vertical className={styles.rootLayout}>
       <div
         className={styles.rulesWrapper}
-        style={editing !== false ? ({ "--version-color": versionColour } as React.CSSProperties) : undefined}
+        style={version !== false ? ({ "--version-color": versionColour } as React.CSSProperties) : undefined}
       >
-        {editing !== false && (
+        {version !== false && (
           <Flex gap="small" justify="space-between" wrap className={styles.actionBar}>
-            <VersionBar ruleInfo={ruleInfo} version={editing.toString()} />
+            <VersionBar ruleInfo={ruleInfo} version={version.toString()} />
             <SavePublish
               ruleInfo={ruleInfo}
               ruleContent={ruleContent}
-              version={editing}
+              version={version}
               setHasSaved={() => setHasUnsavedChanges(false)}
             />
           </Flex>
@@ -188,6 +188,7 @@ export default function RuleManager({
       {scenarios && rulemap && (
         <ScenariosManager
           ruleId={ruleId}
+          ruleInfo={ruleInfo}
           jsonFile={jsonFile}
           ruleContent={ruleContent}
           rulemap={rulemap}
@@ -200,9 +201,7 @@ export default function RuleManager({
           simulationContext={simulationContext}
           runSimulation={runSimulation}
           resultsOfSimulation={resultsOfSimulation}
-          branchName={ruleInfo.reviewBranch}
-          pathName={ruleInfo.filepath}
-          isInReviewMode={editing === RULE_VERSION.inReview}
+          version={version}
         />
       )}
     </Flex>

--- a/app/components/RuleViewerEditor/subcomponents/LinkRuleComponent.tsx
+++ b/app/components/RuleViewerEditor/subcomponents/LinkRuleComponent.tsx
@@ -92,7 +92,7 @@ export default function LinkRuleComponent({ specification, id, isSelected, name,
               <RuleManager
                 ruleInfo={{ _id: id, filepath }}
                 initialRuleContent={selectedRuleContent}
-                editing={false}
+                version={false}
                 showAllScenarioTabs={false}
               />
             )}

--- a/app/components/ScenariosManager/ScenarioCSV/NewScenarioCSV.module.css
+++ b/app/components/ScenariosManager/ScenarioCSV/NewScenarioCSV.module.css
@@ -1,0 +1,58 @@
+.instructionsList {
+  list-style: none;
+  padding: 20px;
+  margin: 20px 0;
+  background-color: #f4f4f9;
+  border-radius: var(--border-radius);
+  border: 1px solid #eaeaea;
+}
+
+.instructionsList li {
+  margin-bottom: 15px;
+  padding: 10px;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  font-size: 16px;
+  line-height: 1.5;
+  position: relative;
+}
+
+.instructionsList li::before {
+  content: counter(li);
+  counter-increment: li;
+  position: absolute;
+  left: -30px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--color-link-focus);
+  color: white;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.instructionsList a {
+  color: var(--color-link-focus);
+  text-decoration: none;
+}
+
+.instructionsList a:hover {
+  text-decoration: underline;
+}
+
+.instructionsList {
+  counter-reset: li;
+  max-width: calc(100% - 48px);
+}
+
+.upload {
+  margin-right: 10px;
+}
+
+.runButton {
+  margin-left: 10px;
+}

--- a/app/components/ScenariosManager/ScenarioCSV/NewScenarioCSV.tsx
+++ b/app/components/ScenariosManager/ScenarioCSV/NewScenarioCSV.tsx
@@ -13,6 +13,7 @@ interface NewScenarioCSVProps {
   confirmAddingNewCSVFile: (file: File) => void;
   cancelAddingCSVFile: () => void;
   runCSVScenarios: (fileToRun: File | null, filename: string) => void;
+  existingFilenames: string[];
 }
 
 export default function NewScenarioCSV({
@@ -22,6 +23,7 @@ export default function NewScenarioCSV({
   confirmAddingNewCSVFile,
   cancelAddingCSVFile,
   runCSVScenarios,
+  existingFilenames,
 }: NewScenarioCSVProps) {
   const { message } = App.useApp();
 
@@ -67,7 +69,7 @@ export default function NewScenarioCSV({
         <Button key="back" onClick={handleCancel}>
           Return
         </Button>,
-        <Button key="ok" type="primary" onClick={handleOk}>
+        <Button key="ok" type="primary" onClick={handleOk} disabled={file == null}>
           Add to table list
         </Button>,
       ]}
@@ -88,11 +90,17 @@ export default function NewScenarioCSV({
                 accept=".csv"
                 multiple={false}
                 maxCount={1}
-                customRequest={({ file, onSuccess }) => {
-                  setFile(file as File);
-                  message.success(`${(file as File).name} file uploaded successfully.`);
-                  onSuccess && onSuccess("ok");
-                  setUploadedFile(true);
+                customRequest={({ file, onSuccess, onError }) => {
+                  const fileName = (file as File).name;
+                  if (!existingFilenames.includes(fileName)) {
+                    setFile(file as File);
+                    message.success(`${fileName} file uploaded successfully.`);
+                    onSuccess && onSuccess("ok");
+                    setUploadedFile(true);
+                  } else {
+                    message.error("File name already exists");
+                    onError && onError(new Error("File name already exists"));
+                  }
                 }}
                 onRemove={deleteCurrentCSV}
                 showUploadList={true}
@@ -106,7 +114,7 @@ export default function NewScenarioCSV({
             </label>
           </li>
           <li>
-            Run the scenarios against the GO Rules JSON file:{" "}
+            Run the uploaded scenarios against the rule (Optional):{" "}
             <Button
               disabled={!uploadedFile}
               size="large"
@@ -117,7 +125,6 @@ export default function NewScenarioCSV({
               Run Upload Scenarios
             </Button>
           </li>
-          <li>Receive a csv file with the results! 🎉</li>
         </ol>
       </Flex>
     </Modal>

--- a/app/components/ScenariosManager/ScenarioCSV/NewScenarioCSV.tsx
+++ b/app/components/ScenariosManager/ScenarioCSV/NewScenarioCSV.tsx
@@ -43,6 +43,14 @@ export default function NewScenarioCSV({
     setUploadedFile(false);
   };
 
+  const handleOk = () => {
+    file && confirmAddingNewCSVFile(file);
+  };
+
+  const handleCancel = () => {
+    cancelAddingCSVFile();
+  };
+
   useEffect(() => {
     if (openNewCSVModal) {
       deleteCurrentCSV();
@@ -53,8 +61,16 @@ export default function NewScenarioCSV({
     <Modal
       title="Create new CSV test file"
       open={openNewCSVModal}
-      onOk={() => file && confirmAddingNewCSVFile(file)}
-      onCancel={() => cancelAddingCSVFile()}
+      onOk={handleOk}
+      onCancel={handleCancel}
+      footer={[
+        <Button key="back" onClick={handleCancel}>
+          Return
+        </Button>,
+        <Button key="ok" type="primary" onClick={handleOk}>
+          Add to table list
+        </Button>,
+      ]}
     >
       <Flex gap="small">
         <ol className={styles.instructionsList}>

--- a/app/components/ScenariosManager/ScenarioCSV/NewScenarioCSV.tsx
+++ b/app/components/ScenariosManager/ScenarioCSV/NewScenarioCSV.tsx
@@ -1,0 +1,109 @@
+import { useState, useEffect } from "react";
+import { App, Modal, Button, Flex, Upload } from "antd";
+import { UploadOutlined } from "@ant-design/icons";
+import { DecisionGraphType } from "@gorules/jdm-editor";
+import { logError } from "@/app/utils/logger";
+import { getCSVForRuleRun } from "@/app/utils/api";
+import styles from "./NewScenarioCSV.module.css";
+
+interface NewScenarioCSVProps {
+  openNewCSVModal: boolean;
+  jsonFile: string;
+  ruleContent?: DecisionGraphType;
+  confirmAddingNewCSVFile: (file: File) => void;
+  cancelAddingCSVFile: () => void;
+  runCSVScenarios: (fileToRun: File | null, filename: string) => void;
+}
+
+export default function NewScenarioCSV({
+  openNewCSVModal,
+  jsonFile,
+  ruleContent,
+  confirmAddingNewCSVFile,
+  cancelAddingCSVFile,
+  runCSVScenarios,
+}: NewScenarioCSVProps) {
+  const { message } = App.useApp();
+
+  const [file, setFile] = useState<File | null>(null);
+  const [uploadedFile, setUploadedFile] = useState<boolean>(false);
+
+  const handleDownloadScenarios = async () => {
+    try {
+      const csvContent = await getCSVForRuleRun(jsonFile, ruleContent);
+      message.success(`Scenario Testing Template: ${csvContent}`);
+    } catch (error: unknown) {
+      message.error("Error downloading scenarios.");
+      logError("Error downloading scenarios:", error instanceof Error ? error : "Unknown error occurred.");
+    }
+  };
+
+  const deleteCurrentCSV = () => {
+    setFile(null);
+    setUploadedFile(false);
+  };
+
+  useEffect(() => {
+    if (openNewCSVModal) {
+      deleteCurrentCSV();
+    }
+  }, [openNewCSVModal]);
+
+  return (
+    <Modal
+      title="Create new CSV test file"
+      open={openNewCSVModal}
+      onOk={() => file && confirmAddingNewCSVFile(file)}
+      onCancel={() => cancelAddingCSVFile()}
+    >
+      <Flex gap="small">
+        <ol className={styles.instructionsList}>
+          <li>
+            Download a template CSV file:{" "}
+            <Button onClick={handleDownloadScenarios} size="large" type="primary">
+              Generate Scenarios/Template
+            </Button>
+          </li>
+          <li>Add additional scenarios to the CSV file</li>
+          <li>
+            Upload your edited CSV file with scenarios:{" "}
+            <label className="labelsmall">
+              <Upload
+                accept=".csv"
+                multiple={false}
+                maxCount={1}
+                customRequest={({ file, onSuccess }) => {
+                  setFile(file as File);
+                  message.success(`${(file as File).name} file uploaded successfully.`);
+                  onSuccess && onSuccess("ok");
+                  setUploadedFile(true);
+                }}
+                onRemove={deleteCurrentCSV}
+                showUploadList={true}
+                className={styles.upload}
+              >
+                <Button size="large" type="primary" icon={<UploadOutlined />}>
+                  Upload Scenarios
+                </Button>
+              </Upload>
+              {!file ? `Select file for upload.` : `File Selected.`}
+            </label>
+          </li>
+          <li>
+            Run the scenarios against the GO Rules JSON file:{" "}
+            <Button
+              disabled={!uploadedFile}
+              size="large"
+              type="primary"
+              onClick={() => runCSVScenarios(file, file?.name || "local-tests.csv")}
+              className={styles.runButton}
+            >
+              Run Upload Scenarios
+            </Button>
+          </li>
+          <li>Receive a csv file with the results! 🎉</li>
+        </ol>
+      </Flex>
+    </Modal>
+  );
+}

--- a/app/components/ScenariosManager/ScenarioCSV/ScenarioCSV.module.css
+++ b/app/components/ScenariosManager/ScenarioCSV/ScenarioCSV.module.css
@@ -1,57 +1,9 @@
-.instructionsList {
-  list-style: none;
-  padding: 20px;
-  margin: 20px 0;
-  background-color: #f4f4f9;
-  border-radius: var(--border-radius);
-  border: 1px solid #eaeaea;
+.filenameColumn {
+  min-width: 400px;
+  word-break: break-all;
 }
 
-.instructionsList li {
-  margin-bottom: 15px;
-  padding: 10px;
-  background: #fff;
-  border-radius: 6px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  font-size: 16px;
-  line-height: 1.5;
-  position: relative;
-}
-
-.instructionsList li::before {
-  content: counter(li);
-  counter-increment: li;
-  position: absolute;
-  left: -30px;
-  top: 50%;
-  transform: translateY(-50%);
-  background: var(--color-link-focus);
-  color: white;
-  border-radius: 50%;
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.instructionsList a {
-  color: var(--color-link-focus);
-  text-decoration: none;
-}
-
-.instructionsList a:hover {
-  text-decoration: underline;
-}
-
-.instructionsList {
-  counter-reset: li;
-}
-
-.upload {
-  margin-right: 10px;
-}
-
-.runButton {
-  margin-left: 10px;
+.runResultIcon {
+  display: block !important;
+  font-size: 20px;
 }

--- a/app/components/ScenariosManager/ScenarioCSV/ScenarioCSV.tsx
+++ b/app/components/ScenariosManager/ScenarioCSV/ScenarioCSV.tsx
@@ -70,7 +70,6 @@ export default function ScenarioCSV({ ruleInfo, jsonFile, ruleContent, version }
    */
   const rowSelection: TableProps<any>["rowSelection"] = {
     onChange: (selectedRowKeys: React.Key[], selectedRows: CSVRow[]) => {
-      console.log("Selected rows: ", selectedRows);
       setCurrentlySelectedRows(selectedRows);
     },
   };
@@ -294,6 +293,7 @@ export default function ScenarioCSV({ ruleInfo, jsonFile, ruleContent, version }
         confirmAddingNewCSVFile={confirmAddingNewCSVFile}
         cancelAddingCSVFile={handleCancelAddingCSVFile}
         runCSVScenarios={runCSVScenarios}
+        existingFilenames={csvTableData.map(({ filename }) => filename)}
       />
     </div>
   );

--- a/app/components/ScenariosManager/ScenarioCSV/ScenarioCSV.tsx
+++ b/app/components/ScenariosManager/ScenarioCSV/ScenarioCSV.tsx
@@ -1,97 +1,289 @@
-import { useState } from "react";
-import { Button, Flex, Upload, message } from "antd";
-import { UploadOutlined } from "@ant-design/icons";
+import { useState, useEffect } from "react";
+import dayjs from "dayjs";
+import axios from "axios";
+import { App, Button, Flex, Spin, Table, TableProps } from "antd";
+import { CheckCircleFilled, CloseCircleFilled } from "@ant-design/icons";
 import { DecisionGraphType } from "@gorules/jdm-editor";
 import { logError } from "@/app/utils/logger";
-import { uploadCSVAndProcess, getCSVForRuleRun } from "@/app/utils/api";
+import { CSVRow, CSVRowData } from "@/app/types/csv";
+import { uploadCSVAndProcess } from "@/app/utils/api";
+import { getCSVTestFilesFromBranch, addCSVTestFileToReview, removeCSVTestFileFromReview } from "@/app/utils/githubApi";
+import NewScenarioCSV from "./NewScenarioCSV";
 import styles from "./ScenarioCSV.module.css";
 
 interface ScenarioCSVProps {
   jsonFile: string;
   ruleContent?: DecisionGraphType;
+  branchName?: string;
+  pathName: string;
+  isInReviewMode: boolean;
 }
 
-export default function ScenarioCSV({ jsonFile, ruleContent }: ScenarioCSVProps) {
-  const [file, setFile] = useState<File | null>(null);
-  const [uploadedFile, setUploadedFile] = useState(false);
+export default function ScenarioCSV({ jsonFile, ruleContent, branchName, pathName, isInReviewMode }: ScenarioCSVProps) {
+  const { message } = App.useApp();
+  const [openNewCSVModal, setOpenNewCSVModal] = useState(false);
+  const [isLoadingInTestFiles, setIsLoadingInTestFiles] = useState(true);
+  const [githubCSVTestsData, setGithubCSVTestsData] = useState<CSVRowData[]>([]);
+  const [localTestFiles, setLocalTestFiles] = useState<File[]>([]);
+  const [csvTableData, setCSVTableData] = useState<CSVRow[]>([]);
+  const [scenarioRunResults, setScenarioRunResults] = useState<Record<string, boolean>>({});
+  const [currentlySelectedRows, setCurrentlySelectedRows] = useState<CSVRow[]>([]);
 
-  const handleRunUploadScenarios = async () => {
-    if (!file) {
+  /**
+   * Create a new row for the table
+   */
+  const createRow = (fileRowData: CSVRowData, isLocal: boolean = false): CSVRow => {
+    const { filename, downloadFile, lastUpdated, updatedBy } = fileRowData;
+    return {
+      key: filename,
+      filename,
+      downloadFile,
+      lastUpdated,
+      updatedBy,
+      actions: (
+        <Flex gap={8}>
+          <Button onClick={() => runCSVScenarios(downloadFile, filename)}>Run Scenarios</Button>
+          {isInReviewMode &&
+            (isLocal ? (
+              <Button onClick={() => addCSVToReview(fileRowData)}>Add to Review</Button>
+            ) : (
+              <Button danger type="dashed" onClick={() => removeCSVFromReview(filename)}>
+                Delete from Review
+              </Button>
+            ))}
+          {isLocal && (
+            <Button danger type="dashed" onClick={() => deleteLocalCSV(filename)}>
+              Delete
+            </Button>
+          )}
+        </Flex>
+      ),
+    };
+  };
+
+  /**
+   * Select multiple rows to run bulk operations
+   */
+  const rowSelection: TableProps<any>["rowSelection"] = {
+    onChange: (selectedRowKeys: React.Key[], selectedRows: CSVRow[]) => {
+      console.log("Selected rows: ", selectedRows);
+      setCurrentlySelectedRows(selectedRows);
+    },
+  };
+
+  /**
+   * Run CSV Scenarios for a test file
+   */
+  const runCSVScenarios = async (fileToRun: File | string | null, filename: string) => {
+    if (!fileToRun) {
       message.error("No file uploaded.");
       return;
     }
     try {
-      const csvContent = await uploadCSVAndProcess(file, jsonFile, ruleContent);
-      message.success(`Scenarios Test: ${csvContent}`);
+      if (typeof fileToRun === "string") {
+        const response = await axios.get(fileToRun as string, {
+          responseType: "blob", // Ensure the response is a Blob
+        });
+        const blob = response.data;
+        fileToRun = new File([blob], filename, { type: blob.type });
+      }
+      if (!fileToRun || typeof fileToRun === "string") {
+        throw new Error("Cannot get valid file");
+      }
+      // Process it
+      const { successMessage, allTestsPassed } = await uploadCSVAndProcess(fileToRun, jsonFile, ruleContent);
+      // Update run result value in the table
+      setScenarioRunResults((prevValues) => {
+        const updatedValues = { ...prevValues };
+        updatedValues[filename] = allTestsPassed;
+        return updatedValues;
+      });
+      message.success(`Scenarios Test: ${successMessage}`);
     } catch (error: any) {
-      message.error("Error processing scenarios.");
-      logError("Error:", error);
+      message.error("Error processing scenarios");
+      logError("Error processing scenarios:", error);
     }
   };
 
-  const handleDownloadScenarios = async () => {
+  /**
+   * Run all scenarios for selected CSV test files
+   */
+  const runAllSelectedCSVScenarios = () => {
+    currentlySelectedRows.forEach(({ downloadFile, filename }) => {
+      runCSVScenarios(downloadFile, filename);
+    });
+  };
+
+  /**
+   * Upload to GitHub review
+   */
+  const addCSVToReview = (fileRowData: CSVRowData) => {
     try {
-      const csvContent = await getCSVForRuleRun(jsonFile, ruleContent);
-      message.success(`Scenario Testing Template: ${csvContent}`);
+      if (!branchName) {
+        throw new Error("No branch name exists");
+      }
+      const { filename, downloadFile } = fileRowData;
+      if (!(downloadFile instanceof File)) {
+        throw new Error("No local file to add to review");
+      }
+      const csvPathName = pathName.replace(/[^/]+$/, filename || ""); // Get csv path name from json file name
+      const reader = new FileReader(); // Use FileReader to encode file to base64
+      reader.onload = async () => {
+        const base64Content = reader.result?.toString().split(",")[1];
+        if (base64Content) {
+          await addCSVTestFileToReview(base64Content, branchName, csvPathName);
+          setGithubCSVTestsData([...githubCSVTestsData, fileRowData]);
+          deleteLocalCSV(filename);
+        } else {
+          throw new Error("Failed to encode file to base64");
+        }
+      };
+      reader.onerror = () => {
+        throw new Error("Error reading file");
+      };
+      if (downloadFile) {
+        reader.readAsDataURL(downloadFile);
+      }
     } catch (error: any) {
-      message.error("Error downloading scenarios.");
-      logError("Error:", error);
+      message.error("Error adding CSV to review");
+      console.error("Error adding CSV to review:", error);
     }
   };
+
+  /**
+   * Remove from GitHub review
+   */
+  const removeCSVFromReview = async (filenameToRemove: string) => {
+    try {
+      if (!branchName) {
+        throw new Error("No branch name exists");
+      }
+      const csvPathName = pathName.replace(/[^/]+$/, filenameToRemove);
+      await removeCSVTestFileFromReview(branchName, csvPathName);
+      const githubFilesWithoutRemovedOne = githubCSVTestsData.filter(({ filename }) => filenameToRemove != filename);
+      setGithubCSVTestsData(githubFilesWithoutRemovedOne);
+      message.success("CSV removed from review");
+    } catch (error: any) {
+      message.error("Error removing CSV from review");
+      console.error("Error removing CSV from review:", error);
+    }
+  };
+
+  /**
+   * Delete CSV test file or remove it from review
+   */
+  const deleteLocalCSV = (filenameToRemove: string) => {
+    const localFilesWithoutRemovedOne = localTestFiles.filter(({ name }) => name != filenameToRemove);
+    setLocalTestFiles(localFilesWithoutRemovedOne);
+  };
+
+  /**
+   * Add test file from New modal
+   */
+  const confirmAddingNewCSVFile = (file: File) => {
+    setLocalTestFiles([...localTestFiles, file]);
+    setOpenNewCSVModal(false);
+  };
+
+  /**
+   * Gets scenario test files from GitHub
+   */
+  useEffect(() => {
+    const getGithubCSVTestFiles = async () => {
+      try {
+        const testFiles: CSVRowData[] = await getCSVTestFilesFromBranch(branchName || "main", "/tests/util");
+        setGithubCSVTestsData(testFiles);
+        setIsLoadingInTestFiles(false);
+      } catch (error: any) {
+        message.error("Error getting CSV test files from Github");
+        console.error("Error getting CSV test files from Github:", error);
+      }
+    };
+    getGithubCSVTestFiles();
+  }, []);
+
+  /**
+   * Generates all the rows of data for the table of scenario test files
+   */
+  useEffect(() => {
+    if (githubCSVTestsData == null) return;
+    // Convert github test file data to rows in the table
+    const updatedCSVTableData: CSVRow[] = githubCSVTestsData.map((testFileData) => createRow(testFileData));
+    // Adds any locally updated scenario test file to the table
+    localTestFiles.forEach((file) =>
+      updatedCSVTableData.push(
+        createRow(
+          {
+            filename: file.name,
+            lastUpdated: file?.lastModified,
+            updatedBy: "You",
+            downloadFile: file,
+          },
+          true
+        )
+      )
+    );
+    // Add results of previous runs to the row
+    const updatedCSVTableDataWithRunResults: CSVRow[] = updatedCSVTableData.map((row: CSVRow) => ({
+      ...row,
+      runResult:
+        scenarioRunResults[row.filename] == null ? null : scenarioRunResults[row.filename] ? (
+          <CheckCircleFilled className={styles.runResultIcon} style={{ color: "green" }} />
+        ) : (
+          <CloseCircleFilled className={styles.runResultIcon} style={{ color: "red" }} />
+        ),
+    }));
+    // Sets the updated data
+    setCSVTableData(updatedCSVTableDataWithRunResults);
+  }, [localTestFiles, githubCSVTestsData, scenarioRunResults]);
+
+  const handleCancelAddingCSVFile = () => {
+    setOpenNewCSVModal(false);
+  };
+
+  if (isLoadingInTestFiles) {
+    return (
+      <Spin tip="Loading rules..." size="large" wrapperClassName="spinnerWrapper" style={{ height: 200 }}>
+        <div className="content" />
+      </Spin>
+    );
+  }
 
   return (
     <div>
-      <Flex gap={"small"}>
-        <ol className={styles.instructionsList}>
-          <li>
-            Download a template CSV file:{" "}
-            <Button onClick={handleDownloadScenarios} size="large" type="primary">
-              Generate Scenarios/Template
-            </Button>
-          </li>
-          <li>Add additional scenarios to the CSV file</li>
-          <li>
-            Upload your edited CSV file with scenarios:{" "}
-            <label className="labelsmall">
-              <Upload
-                accept=".csv"
-                multiple={false}
-                maxCount={1}
-                customRequest={({ file, onSuccess }) => {
-                  setFile(file as File);
-                  message.success(`${(file as File).name} file uploaded successfully.`);
-                  onSuccess && onSuccess("ok");
-                  setUploadedFile(true);
-                }}
-                onRemove={() => {
-                  setFile(null);
-                  setUploadedFile(false);
-                }}
-                showUploadList={true}
-                className={styles.upload}
-              >
-                <Button size="large" type="primary" icon={<UploadOutlined />}>
-                  Upload Scenarios
-                </Button>
-              </Upload>
-              {!file ? `Select file for upload.` : `File Selected.`}
-            </label>
-          </li>
-          <li>
-            Run the scenarios against the GO Rules JSON file:{" "}
-            <Button
-              disabled={!uploadedFile}
-              size="large"
-              type="primary"
-              onClick={handleRunUploadScenarios}
-              className="styles.runButton"
-            >
-              Run Upload Scenarios
-            </Button>
-          </li>
-          <li>Receive a csv file with the results! 🎉</li>
-        </ol>
+      <Flex vertical gap="large">
+        <Table dataSource={csvTableData} rowSelection={rowSelection} pagination={false}>
+          <Table.Column
+            title="CSV Test Filename"
+            dataIndex="filename"
+            key="filename"
+            render={(text) => <div className={styles.filenameColumn}>{text}</div>}
+          />
+          <Table.Column
+            title="Last Updated"
+            dataIndex="lastUpdated"
+            key="lastUpdated"
+            render={(timestamp: number | string) => dayjs(timestamp).format("MM/DD/YYYY")}
+          />
+          <Table.Column title="Updated By" dataIndex="updatedBy" key="updatedBy" />
+          <Table.Column title="Actions" dataIndex="actions" key="actions" />
+          <Table.Column title="Run Result" dataIndex="runResult" key="runResult" />
+        </Table>
+        <Flex gap="middle">
+          <Button onClick={() => runAllSelectedCSVScenarios()}>Run selected scenario CSVs</Button>
+          <Button type="primary" onClick={() => setOpenNewCSVModal(true)}>
+            + Create new CSV test file
+          </Button>
+        </Flex>
       </Flex>
+      <NewScenarioCSV
+        openNewCSVModal={openNewCSVModal}
+        jsonFile={jsonFile}
+        ruleContent={ruleContent}
+        confirmAddingNewCSVFile={confirmAddingNewCSVFile}
+        cancelAddingCSVFile={handleCancelAddingCSVFile}
+        runCSVScenarios={runCSVScenarios}
+      />
     </div>
   );
 }

--- a/app/components/ScenariosManager/ScenarioHelper/ScenarioHelper.tsx
+++ b/app/components/ScenariosManager/ScenarioHelper/ScenarioHelper.tsx
@@ -376,6 +376,7 @@ export default function ScenariosHelper({ section }: ScenariosHelperProps) {
               You can run the scenarios for those test files by clicking the &apos;Run Scenarios&apos; button in the
               table.
             </p>
+            <p>Any time you run scenarios you&apos;ll recieve a CSV file with the results.</p>
             <p>
               To add a new CSV test file, click the &apos;+ Create new CSV test file&apos; button and follow the
               instructions there.

--- a/app/components/ScenariosManager/ScenarioHelper/ScenarioHelper.tsx
+++ b/app/components/ScenariosManager/ScenarioHelper/ScenarioHelper.tsx
@@ -74,9 +74,9 @@ export default function ScenariosHelper({ section }: ScenariosHelperProps) {
                     button.
                   </p>
                   <p>
-                    The scenario&apos;s saved inputs for the rule are shown in the &apos;Inputs&apos; window, and the final results
-                    will be processed in real time through the current visible version of the rule, and returned in the
-                    &apos;Decision&apos; window.
+                    The scenario&apos;s saved inputs for the rule are shown in the &apos;Inputs&apos; window, and the
+                    final results will be processed in real time through the current visible version of the rule, and
+                    returned in the &apos;Decision&apos; window.
                   </p>
                   <p>
                     By running rules individually, you can track their progress as the scenario is processed by the
@@ -102,8 +102,8 @@ export default function ScenariosHelper({ section }: ScenariosHelperProps) {
                     scenario inputs, or delete a scenario.
                   </p>
                   <p>
-                    Clicking on the edit button will redirect you to the &apos;Simulate manual inputs&apos; tab to update the
-                    inputs and expected results for a scenario.
+                    Clicking on the edit button will redirect you to the &apos;Simulate manual inputs&apos; tab to
+                    update the inputs and expected results for a scenario.
                   </p>
                 </div>
               </section>
@@ -212,8 +212,8 @@ export default function ScenariosHelper({ section }: ScenariosHelperProps) {
                 <div className={styles.sectionContent}>
                   <p>The simulate button runs your current inputs through the rule to generate results.</p>
                   <p>
-                    After a successful simulation, you&apos;ll have the option to save these inputs as a new scenario. This
-                    includes a field to name your scenario and a save button to store it for future use.
+                    After a successful simulation, you&apos;ll have the option to save these inputs as a new scenario.
+                    This includes a field to name your scenario and a save button to store it for future use.
                   </p>
                 </div>
               </section>
@@ -296,8 +296,8 @@ export default function ScenariosHelper({ section }: ScenariosHelperProps) {
                 <h2 className={styles.sectionHeading}>1. Re-Run Scenarios</h2>
                 <div className={styles.sectionContent}>
                   <p>
-                    The &apos;Re-Run Scenarios&apos; button allows you to run all saved scenarios against the current version of
-                    the rule in view.
+                    The &apos;Re-Run Scenarios&apos; button allows you to run all saved scenarios against the current
+                    version of the rule in view.
                   </p>
                   <p>
                     This is particularly useful when making changes to a rule, as it allows you to verify that all
@@ -318,7 +318,9 @@ export default function ScenariosHelper({ section }: ScenariosHelperProps) {
                         <li>No expected results were specified (default pass state)</li>
                       </ul>
                     </li>
-                    <li>A red X (✗) indicates the scenario&apos;s actual results don&apos;t match the expected results</li>
+                    <li>
+                      A red X (✗) indicates the scenario&apos;s actual results don&apos;t match the expected results
+                    </li>
                   </ul>
                 </div>
               </section>
@@ -340,15 +342,22 @@ export default function ScenariosHelper({ section }: ScenariosHelperProps) {
                 <div className={styles.sectionContent}>
                   <p>The table provides several controls for managing the view of your scenarios:</p>
                   <ul>
-                    <li>&apos;Show Error Scenarios&apos; - Instantly filters the list to display only scenarios with errors</li>
-                    <li>&apos;Clear Filters and Sorters&apos; - Resets all active filters and sorting to their default state</li>
+                    <li>
+                      &apos;Show Error Scenarios&apos; - Instantly filters the list to display only scenarios with
+                      errors
+                    </li>
+                    <li>
+                      &apos;Clear Filters and Sorters&apos; - Resets all active filters and sorting to their default
+                      state
+                    </li>
                   </ul>
                   <p>Additional filtering and sorting options:</p>
                   <ul>
                     <li>Each column can be filtered based on its content</li>
                     <li>Columns can be sorted in ascending or descending order</li>
                     <li>
-                      All filtering and sorting is visual only and doesn&apos;t affect the underlying scenarios or results
+                      All filtering and sorting is visual only and doesn&apos;t affect the underlying scenarios or
+                      results
                     </li>
                   </ul>
                 </div>
@@ -359,7 +368,22 @@ export default function ScenariosHelper({ section }: ScenariosHelperProps) {
       case ScenariosManagerTabs.CSVTab:
         return (
           <div>
-            <p>Follow the instructions within this tab to utilize CSV tests.</p>
+            <p>
+              Scenario CSV test files will show up in the table below. It will list both test files that are stored on
+              GitHub as well as locally uploaded ones.
+            </p>
+            <p>
+              You can run the scenarios for those test files by clicking the &apos;Run Scenarios&apos; button in the
+              table.
+            </p>
+            <p>
+              To add a new CSV test file, click the &apos;+ Create new CSV test file&apos; button and follow the
+              instructions there.
+            </p>
+            <p>
+              When you are doing a review, the &apos;Add to Review&apos; button will appear in the table and you can use
+              that to add your local test files to the review and have them stored in GitHub.
+            </p>
             <p>
               Specific details about the CSV Tests tab are available on The Hive:{" "}
               <a

--- a/app/components/ScenariosManager/ScenariosManager.tsx
+++ b/app/components/ScenariosManager/ScenariosManager.tsx
@@ -26,6 +26,9 @@ interface ScenariosManagerProps {
   setSimulationContext: (newContext: Record<string, any>) => void;
   runSimulation: (newContext?: Record<string, any>) => void;
   resultsOfSimulation?: Record<string, any> | null;
+  branchName?: string;
+  pathName: string;
+  isInReviewMode: boolean;
 }
 
 export enum ScenariosManagerTabs {
@@ -50,6 +53,9 @@ export default function ScenariosManager({
   setSimulationContext,
   runSimulation,
   resultsOfSimulation,
+  branchName,
+  pathName,
+  isInReviewMode,
 }: ScenariosManagerProps) {
   const [resetTrigger, setResetTrigger] = useState<boolean>(false);
   const [activeTabKey, setActiveTabKey] = useState<string>(
@@ -127,7 +133,13 @@ export default function ScenariosManager({
 
     const csvTab = (
       <Flex gap="small">
-        <ScenarioCSV jsonFile={jsonFile} ruleContent={ruleContent} />
+        <ScenarioCSV
+          jsonFile={jsonFile}
+          ruleContent={ruleContent}
+          branchName={branchName}
+          pathName={pathName}
+          isInReviewMode={isInReviewMode}
+        />
       </Flex>
     );
 

--- a/app/components/ScenariosManager/ScenariosManager.tsx
+++ b/app/components/ScenariosManager/ScenariosManager.tsx
@@ -2,8 +2,10 @@ import React, { useState, useMemo, useCallback } from "react";
 import { Flex, Button, Tabs } from "antd";
 import type { TabsProps } from "antd";
 import { DecisionGraphType } from "@gorules/jdm-editor";
+import { RuleInfo } from "@/app/types/ruleInfo";
 import { Scenario } from "@/app/types/scenario";
 import { RuleMap } from "@/app/types/rulemap";
+import { RULE_VERSION } from "@/app/constants/ruleVersion";
 import ScenarioViewer from "./ScenarioViewer";
 import ScenarioGenerator from "./ScenarioGenerator";
 import ScenarioResults from "./ScenarioResults";
@@ -14,6 +16,7 @@ import ScenariosHelper from "./ScenarioHelper/ScenarioHelper";
 
 interface ScenariosManagerProps {
   ruleId: string;
+  ruleInfo: RuleInfo;
   jsonFile: string;
   ruleContent: DecisionGraphType;
   rulemap: RuleMap;
@@ -26,9 +29,7 @@ interface ScenariosManagerProps {
   setSimulationContext: (newContext: Record<string, any>) => void;
   runSimulation: (newContext?: Record<string, any>) => void;
   resultsOfSimulation?: Record<string, any> | null;
-  branchName?: string;
-  pathName: string;
-  isInReviewMode: boolean;
+  version: RULE_VERSION | boolean;
 }
 
 export enum ScenariosManagerTabs {
@@ -41,6 +42,7 @@ export enum ScenariosManagerTabs {
 
 export default function ScenariosManager({
   ruleId,
+  ruleInfo,
   jsonFile,
   ruleContent,
   rulemap,
@@ -53,9 +55,7 @@ export default function ScenariosManager({
   setSimulationContext,
   runSimulation,
   resultsOfSimulation,
-  branchName,
-  pathName,
-  isInReviewMode,
+  version,
 }: ScenariosManagerProps) {
   const [resetTrigger, setResetTrigger] = useState<boolean>(false);
   const [activeTabKey, setActiveTabKey] = useState<string>(
@@ -133,13 +133,7 @@ export default function ScenariosManager({
 
     const csvTab = (
       <Flex gap="small">
-        <ScenarioCSV
-          jsonFile={jsonFile}
-          ruleContent={ruleContent}
-          branchName={branchName}
-          pathName={pathName}
-          isInReviewMode={isInReviewMode}
-        />
+        <ScenarioCSV ruleInfo={ruleInfo} jsonFile={jsonFile} ruleContent={ruleContent} version={version} />
       </Flex>
     );
 
@@ -199,6 +193,7 @@ export default function ScenariosManager({
     scenarios,
     rulemap,
     ruleId,
+    ruleInfo,
     jsonFile,
     setSimulationContext,
     resultsOfSimulation,
@@ -213,6 +208,7 @@ export default function ScenariosManager({
     handleReset,
     scenarioName,
     setScenarios,
+    version,
   ]);
 
   return (

--- a/app/rule/[ruleId]/embedded/page.tsx
+++ b/app/rule/[ruleId]/embedded/page.tsx
@@ -11,6 +11,6 @@ export default async function Rule({ params: { ruleId } }: { params: { ruleId: s
   }
 
   return (
-    <RuleManager ruleInfo={ruleInfo} initialRuleContent={ruleContent} editing={false} showAllScenarioTabs={false} />
+    <RuleManager ruleInfo={ruleInfo} initialRuleContent={ruleContent} version={false} showAllScenarioTabs={false} />
   );
 }

--- a/app/rule/[ruleId]/page.tsx
+++ b/app/rule/[ruleId]/page.tsx
@@ -45,7 +45,7 @@ export default async function Rule({ params: { ruleId }, searchParams }: Props) 
         <RuleHeader ruleInfo={ruleInfo} />
         <div style={{ background: "white" }}>
           <div className={styles.rulesWrapper}>
-            <RuleManager ruleInfo={ruleInfo} initialRuleContent={ruleContent} editing={version} />
+            <RuleManager ruleInfo={ruleInfo} initialRuleContent={ruleContent} version={version as RULE_VERSION} />
           </div>
         </div>
       </div>

--- a/app/rule/new/NewRule.tsx
+++ b/app/rule/new/NewRule.tsx
@@ -81,7 +81,7 @@ export default function NewRule() {
           <div className={styles.rulesWrapper}>
             <RuleHeader ruleInfo={ruleInfo} />
             {ruleInfo.filepath && (
-              <RuleManager ruleInfo={ruleInfo} initialRuleContent={DEFAULT_RULE_CONTENT} editing={RULE_VERSION.draft} />
+              <RuleManager ruleInfo={ruleInfo} initialRuleContent={DEFAULT_RULE_CONTENT} version={RULE_VERSION.draft} />
             )}
           </div>
         </div>

--- a/app/types/csv.d.ts
+++ b/app/types/csv.d.ts
@@ -1,0 +1,12 @@
+export interface CSVRowData {
+  filename: string;
+  downloadFile: string | File;
+  lastUpdated: number;
+  updatedBy: string;
+}
+
+export interface CSVRow extends CSVRowData {
+  key: string;
+  actions: JSX.Element;
+  runResult?: JSX.Element | null;
+}

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -346,7 +346,7 @@ export const uploadCSVAndProcess = async (
   file: File,
   filepath: string,
   ruleContent?: DecisionGraphType
-): Promise<string> => {
+): Promise<{ successMessage: string; allTestsPassed: boolean }> => {
   try {
     const response = await axiosAPIInstance.post(
       `/scenario/evaluation/upload/`,
@@ -363,11 +363,12 @@ export const uploadCSVAndProcess = async (
       }
     );
 
+    const allTestsPassed = response.headers["x-all-tests-passed"] === "true";
     const timestamp = new Date().toISOString().replace(/:/g, "-").replace(/\.\d+/, "");
     const filename = `${filepath.replace(".json", "")}_testing_${file.name.replace(".csv", "")}_${timestamp}.csv`;
     downloadFileBlob(response.data, "text/csv", filename);
 
-    return "File processed successfully";
+    return { successMessage: "File processed successfully", allTestsPassed };
   } catch (error) {
     logError(`Error processing CSV file: ${error}`);
     throw new Error("Error processing CSV file");

--- a/app/utils/githubApi.ts
+++ b/app/utils/githubApi.ts
@@ -3,8 +3,7 @@ import { logError } from "./logger";
 import { CSVRowData } from "@/app/types/csv";
 import { getShortFilenameOnly } from "./utils";
 
-// TODO: CHANGE BACK
-const GITHUB_REPO_URL = "https://api.github.com/repos/timwekkenbc/brms-rules-dev";
+const GITHUB_REPO_URL = "https://api.github.com/repos/bcgov/brms-rules";
 const GITHUB_REPO_OWNER = "bcgov";
 const GITHUB_BASE_BRANCH = "dev";
 
@@ -300,8 +299,12 @@ export const getCSVTestFilesFromBranch = async (branchName: string, filePath: st
     );
     return fileDetails;
   } catch (error: any) {
-    logError(`Error getting ${filePath} as JSON for ${branchName}`, error);
-    throw error;
+    if (error.status == 404) {
+      return [];
+    } else {
+      logError(`Error getting ${filePath} as CSV for ${branchName}`, error);
+      throw error;
+    }
   }
 };
 

--- a/app/utils/githubApi.ts
+++ b/app/utils/githubApi.ts
@@ -44,11 +44,11 @@ export const isGithubAuthTokenValid = async (oauthToken?: string): Promise<{ val
   }
   initializeGithubAxiosInstance(oauthToken, githubAuthUsername);
   // Check that the user has authorized the organization (bcgov) properly
-  // try {
-  //   await axiosGithubInstance.get(`${GITHUB_REPO_URL}/git/ref/heads/${GITHUB_BASE_BRANCH}`);
-  // } catch (error) {
-  //   return { valid: false, reason: AuthFailureReasons.NO_ORG_ACCESS };
-  // }
+  try {
+    await axiosGithubInstance.get(`${GITHUB_REPO_URL}/git/ref/heads/${GITHUB_BASE_BRANCH}`);
+  } catch (error) {
+    return { valid: false, reason: AuthFailureReasons.NO_ORG_ACCESS };
+  }
   return { valid: true };
 };
 


### PR DESCRIPTION
- [x] Added functionality for viewing and running previously uploaded CSV tests from Github repo
- [x] Added functionality for adding/removing previously uploaded CSV tests to/from Github repo
- [x] Added functionality for running a bunch of different CSV test files at once
- [x] Added Github API support for saving CSV test files to the repo
- [x] Updated processing of CSV to return if all tests passed successfully or not
- [x] Separated adding new CSV file modal into its own file
- [x] Updated "editing" to "version"
- [x] Updated local documentation to be in line with new changes to CSV tests

Depends on https://github.com/bcgov/brm-backend/pull/62