### PR TITLE
Add isolation tester range inputs and update linked rule input handling.

### DIFF
--- a/app/components/InputStyler/InputStyler.tsx
+++ b/app/components/InputStyler/InputStyler.tsx
@@ -91,7 +91,7 @@ export default function InputStyler(
     }
   };
 
-  const handleValueChange = (value: any, field: string, rangeType?: "minValue" | "maxValue") => {
+  const handleValueChange = (value: any, field: string, range?: boolean) => {
     let queryValue: any = value;
     if (typeof value === "string") {
       if (value === "") queryValue = "";
@@ -99,29 +99,30 @@ export default function InputStyler(
       else if (value.toLowerCase() === "false") queryValue = false;
       else if (!isNaN(Number(value))) queryValue = Number(value);
     }
-
-    if (range && rangeType) {
-      const currentValue =
-        typeof rawData?.[field] === "object" ? { ...rawData[field] } : { minValue: null, maxValue: null };
-      currentValue[rangeType] = queryValue;
-      updateFieldValue(field, currentValue);
-    } else {
-      updateFieldValue(field, queryValue);
-    }
+    if (range) return queryValue;
+    updateFieldValue(field, queryValue);
   };
 
-  const handleInputChange = (value: any, field: string, rangeType?: "minValue" | "maxValue") => {
-    if (range && rangeType) {
-      const currentValue = rawData?.[field] || {};
-      if (value === null || value === undefined) {
-        delete currentValue[rangeType];
-        updateFieldValue(field, Object.keys(currentValue).length === 0 ? undefined : currentValue);
-      } else {
-        currentValue[rangeType] = value;
-        updateFieldValue(field, currentValue);
-      }
+  const handleInputChange = (value: any, field: string) => {
+    updateFieldValue(field, value);
+  };
+
+  const handleRangeValueChange = (value: any, field: string, rangeType: "minValue" | "maxValue") => {
+    let queryValue = handleValueChange(value, field, true);
+    const currentValue =
+      typeof rawData?.[field] === "object" ? { ...rawData[field] } : { minValue: null, maxValue: null };
+    currentValue[rangeType] = queryValue;
+    updateFieldValue(field, currentValue);
+  };
+
+  const handleRangeInputChange = (value: any, field: string, rangeType: "minValue" | "maxValue") => {
+    const currentValue = rawData?.[field] || {};
+    if (value === null || value === undefined) {
+      delete currentValue[rangeType];
+      handleInputChange(Object.keys(currentValue).length === 0 ? undefined : currentValue, field);
     } else {
-      updateFieldValue(field, value);
+      currentValue[rangeType] = value;
+      handleInputChange(currentValue, field);
     }
   };
 
@@ -205,8 +206,8 @@ export default function InputStyler(
             value={value}
             field={field}
             valuesArray={valuesArray}
-            handleValueChange={handleValueChange}
-            handleInputChange={handleInputChange}
+            handleValueChange={(val: any) => handleValueChange(val, field)}
+            handleInputChange={(val: any) => handleInputChange(val, field)}
             handleClear={handleClear}
           />
         );
@@ -221,8 +222,12 @@ export default function InputStyler(
                 field={field}
                 maximum={validationRules?.range ? validationRules?.range.max : validationRules?.max}
                 minimum={validationRules?.range ? validationRules?.range.min : validationRules?.min}
-                handleValueChange={(val: any) => handleValueChange(val, field, range ? "minValue" : undefined)}
-                handleInputChange={(val: any) => handleInputChange(val, field, range ? "minValue" : undefined)}
+                handleValueChange={(val: any) =>
+                  range ? handleRangeValueChange(val, field, "minValue") : handleValueChange(val, field)
+                }
+                handleInputChange={(val: any) =>
+                  range ? handleRangeInputChange(val, field, "minValue") : handleInputChange(val, field)
+                }
               />
             </Flex>
             {range && (
@@ -234,8 +239,8 @@ export default function InputStyler(
                   field={field}
                   maximum={validationRules?.range ? validationRules?.range.max : validationRules?.max}
                   minimum={validationRules?.range ? validationRules?.range.min : validationRules?.min}
-                  handleValueChange={(val: any) => handleValueChange(val, field, "maxValue")}
-                  handleInputChange={(val: any) => handleInputChange(val, field, "maxValue")}
+                  handleValueChange={(val: any) => handleRangeValueChange(val, field, "maxValue")}
+                  handleInputChange={(val: any) => handleRangeInputChange(val, field, "maxValue")}
                 />
               </Flex>
             )}
@@ -252,7 +257,9 @@ export default function InputStyler(
                 field={field}
                 maximum={validationRules?.range ? validationRules?.range.max : validationRules?.max}
                 minimum={validationRules?.range ? validationRules?.range.min : validationRules?.min}
-                handleInputChange={(val: any) => handleInputChange(val, field, range ? "minValue" : undefined)}
+                handleInputChange={(val: any) =>
+                  range ? handleRangeInputChange(val, field, "minValue") : handleInputChange(val, field)
+                }
                 handleClear={() => handleClear(field, range ? "minValue" : undefined)}
               />
             </Flex>
@@ -265,7 +272,7 @@ export default function InputStyler(
                   field={field}
                   maximum={validationRules?.range ? validationRules?.range.max : validationRules?.max}
                   minimum={validationRules?.range ? validationRules?.range.min : validationRules?.min}
-                  handleInputChange={(val: any) => handleInputChange(val, field, "maxValue")}
+                  handleInputChange={(val: any) => handleRangeInputChange(val, field, "maxValue")}
                   handleClear={() => handleClear(field, "maxValue")}
                 />
               </Flex>

--- a/app/components/InputStyler/InputStyler.tsx
+++ b/app/components/InputStyler/InputStyler.tsx
@@ -91,15 +91,18 @@ export default function InputStyler(
     }
   };
 
-  const handleValueChange = (value: any, field: string, range?: boolean) => {
-    let queryValue: any = value;
+  const processValue = (value: string | number | boolean): string | number | boolean => {
     if (typeof value === "string") {
-      if (value === "") queryValue = "";
-      else if (value.toLowerCase() === "true") queryValue = true;
-      else if (value.toLowerCase() === "false") queryValue = false;
-      else if (!isNaN(Number(value))) queryValue = Number(value);
+      const lowerValue = value.toLowerCase();
+      if (lowerValue === "true") return true;
+      if (lowerValue === "false") return false;
+      if (!isNaN(Number(value))) return Number(value);
     }
-    if (range) return queryValue;
+    return value;
+  };
+
+  const handleValueChange = (value: string | number | boolean, field: string) => {
+    const queryValue = processValue(value);
     updateFieldValue(field, queryValue);
   };
 
@@ -108,7 +111,7 @@ export default function InputStyler(
   };
 
   const handleRangeValueChange = (value: any, field: string, rangeType: "minValue" | "maxValue") => {
-    let queryValue = handleValueChange(value, field, true);
+    let queryValue = processValue(value);
     const currentValue =
       typeof rawData?.[field] === "object" ? { ...rawData[field] } : { minValue: null, maxValue: null };
     currentValue[rangeType] = queryValue;
@@ -119,10 +122,10 @@ export default function InputStyler(
     const currentValue = rawData?.[field] || {};
     if (value === null || value === undefined) {
       delete currentValue[rangeType];
-      handleInputChange(Object.keys(currentValue).length === 0 ? undefined : currentValue, field);
+      updateFieldValue(field, Object.keys(currentValue).length === 0 ? undefined : currentValue);
     } else {
       currentValue[rangeType] = value;
-      handleInputChange(currentValue, field);
+      updateFieldValue(field, currentValue);
     }
   };
 

--- a/app/components/RuleManager/RuleManager.tsx
+++ b/app/components/RuleManager/RuleManager.tsx
@@ -84,6 +84,8 @@ export default function RuleManager({
     };
     const updateRuleMap = async () => {
       const updatedRulemap: RuleMap = await getRuleMap(jsonFile, ruleContent);
+      // Exclude inputs from linked rules
+      updatedRulemap.inputs = updatedRulemap.inputs.filter((input) => !input.nested);
       setRulemap(updatedRulemap);
       const ruleMapInputs = createRuleMap(updatedRulemap?.inputs, simulationContext);
       setSimulationContext(ruleMapInputs);

--- a/app/components/RuleManager/RuleManager.tsx
+++ b/app/components/RuleManager/RuleManager.tsx
@@ -52,6 +52,7 @@ export default function RuleManager({
   const [scenarios, setScenarios] = useState<Scenario[]>([]);
   const [ruleContent, setRuleContent] = useState<DecisionGraphType>();
   const [rulemap, setRulemap] = useState<RuleMap>();
+  const [nestedRuleMap, setNestedRuleMap] = useState<RuleMap>();
   const [simulation, setSimulation] = useState<Simulation>();
   const [simulationContext, setSimulationContext] = useState<Record<string, any>>();
   const [resultsOfSimulation, setResultsOfSimulation] = useState<Record<string, any> | null>();
@@ -84,6 +85,7 @@ export default function RuleManager({
     };
     const updateRuleMap = async () => {
       const updatedRulemap: RuleMap = await getRuleMap(jsonFile, ruleContent);
+      setNestedRuleMap(updatedRulemap);
       // Exclude inputs from linked rules
       updatedRulemap.inputs = updatedRulemap.inputs.filter((input) => !input.nested);
       setRulemap(updatedRulemap);
@@ -164,6 +166,7 @@ export default function RuleManager({
               ruleContent={ruleContent}
               version={version}
               setHasSaved={() => setHasUnsavedChanges(false)}
+              ruleMap={nestedRuleMap}
             />
           </Flex>
         )}

--- a/app/components/SavePublish/SavePublish.tsx
+++ b/app/components/SavePublish/SavePublish.tsx
@@ -11,15 +11,17 @@ import NewReviewForm from "./NewReviewForm";
 import SavePublishWarnings from "./SavePublishWarnings";
 import styles from "./SavePublish.module.css";
 import RuleMapHelper from "./RuleMapHelper";
+import { RuleMap } from "@/app/types/rulemap";
 
 interface SavePublishProps {
   ruleInfo: RuleInfo;
   ruleContent: DecisionGraphType;
   setHasSaved: () => void;
   version?: string | boolean;
+  ruleMap?: RuleMap;
 }
 
-export default function SavePublish({ ruleInfo, ruleContent, setHasSaved, version }: SavePublishProps) {
+export default function SavePublish({ ruleInfo, ruleContent, setHasSaved, version, ruleMap }: SavePublishProps) {
   const { _id: ruleId, filepath: filePath, reviewBranch } = ruleInfo;
 
   const { message } = App.useApp();
@@ -141,7 +143,7 @@ export default function SavePublish({ ruleInfo, ruleContent, setHasSaved, versio
           </Flex>
         )}
       </Flex>
-      <SavePublishWarnings filePath={filePath} ruleContent={ruleContent} isSaving={isSaving} />
+      <SavePublishWarnings filePath={filePath} ruleContent={ruleContent} isSaving={isSaving} ruleMap={ruleMap} />
     </>
   );
 }

--- a/app/components/SavePublish/SavePublishWarnings.tsx
+++ b/app/components/SavePublish/SavePublishWarnings.tsx
@@ -24,9 +24,14 @@ export default function SavePublishWarnings({ filePath, ruleContent, isSaving }:
   const getMisconnectedFields = async () => {
     // TODO: Move these API calls locally to reduce strain on server (if this solution is working well)
     // Get map from input/output nodes
+    // exludes the inputs and outputs from linked rules
     const inputOutputSchemaMap = await getRuleMap(filePath, ruleContent);
-    const existingKlammInputs = inputOutputSchemaMap.inputs.map(({ field }) => field as string);
-    const existingKlammOutputs = inputOutputSchemaMap.resultOutputs.map(({ field }) => field as string);
+    const existingKlammInputs = inputOutputSchemaMap.inputs
+      .filter((input) => !input.nested)
+      .map(({ field }) => field as string);
+    const existingKlammOutputs = inputOutputSchemaMap.resultOutputs
+      .filter((output) => !output.nested)
+      .map(({ field }) => field as string);
 
     if (!ruleContent?.nodes || ruleContent.nodes.length < 2) return;
 

--- a/app/components/SavePublish/SavePublishWarnings.tsx
+++ b/app/components/SavePublish/SavePublishWarnings.tsx
@@ -4,11 +4,13 @@ import { WarningFilled } from "@ant-design/icons";
 import { DecisionGraphType } from "@gorules/jdm-editor";
 import { getRuleMap, generateSchemaFromRuleContent } from "@/app/utils/api";
 import styles from "./SavePublish.module.css";
+import { RuleMap } from "@/app/types/rulemap";
 
 interface SavePublishProps {
   filePath: string;
   ruleContent: DecisionGraphType;
   isSaving: boolean;
+  ruleMap?: RuleMap;
 }
 
 interface MisconnectedField {
@@ -16,22 +18,20 @@ interface MisconnectedField {
   describer: string;
 }
 
-export default function SavePublishWarnings({ filePath, ruleContent, isSaving }: SavePublishProps) {
+export default function SavePublishWarnings({ filePath, ruleContent, isSaving, ruleMap }: SavePublishProps) {
   const { notification } = App.useApp();
   const [misconnectedFields, setMisconnectedFields] = useState<MisconnectedField[]>([]);
   const [misconnectedFieldsPanelOpen, setMisconnectedFieldsPanelOpen] = useState(false);
 
+  const getFieldsFromSchema = (schema: { field?: string; nested?: string | boolean }[]) =>
+    schema.filter((item) => !item.nested && item.field).map(({ field }) => field as string);
+
   const getMisconnectedFields = async () => {
-    // TODO: Move these API calls locally to reduce strain on server (if this solution is working well)
     // Get map from input/output nodes
     // exludes the inputs and outputs from linked rules
-    const inputOutputSchemaMap = await getRuleMap(filePath, ruleContent);
-    const existingKlammInputs = inputOutputSchemaMap.inputs
-      .filter((input) => !input.nested)
-      .map(({ field }) => field as string);
-    const existingKlammOutputs = inputOutputSchemaMap.resultOutputs
-      .filter((output) => !output.nested)
-      .map(({ field }) => field as string);
+    const inputOutputSchemaMap = ruleMap ?? (await getRuleMap(filePath, ruleContent));
+    const existingKlammInputs = getFieldsFromSchema(inputOutputSchemaMap.inputs);
+    const existingKlammOutputs = getFieldsFromSchema(inputOutputSchemaMap.resultOutputs);
 
     if (!ruleContent?.nodes || ruleContent.nodes.length < 2) return;
 
@@ -87,7 +87,7 @@ export default function SavePublishWarnings({ filePath, ruleContent, isSaving }:
   useEffect(() => {
     getMisconnectedFields();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ruleContent]);
+  }, [ruleContent, ruleMap]);
 
   useEffect(() => {
     if (isSaving) {

--- a/app/components/ScenariosManager/IsolationTester/IsolationTester.tsx
+++ b/app/components/ScenariosManager/IsolationTester/IsolationTester.tsx
@@ -61,7 +61,8 @@ export default function IsolationTester({
             </li>
             <li>
               Define any variables you would like to remain unchanged. The more that you define, the more specific the
-              tests will be.
+              tests will be. Top level variable numbers and dates are entered as ranges. If you would like only one
+              specific number or date, enter the same value for both the minimum and maximum.
               <Collapse
                 items={[
                   {
@@ -77,6 +78,7 @@ export default function IsolationTester({
                               setRawData={(data) => setSimulationContext(data)}
                               scenarios={scenarios}
                               rulemap={rulemap}
+                              range
                             />
                           </Flex>
                         )}

--- a/app/components/ScenariosManager/ScenarioFormatter/ScenarioFormatter.tsx
+++ b/app/components/ScenariosManager/ScenarioFormatter/ScenarioFormatter.tsx
@@ -31,9 +31,17 @@ interface ScenarioFormatterProps {
   setRawData?: (data: object) => void;
   scenarios?: Scenario[];
   rulemap: RuleMap;
+  range?: boolean;
 }
 
-export default function ScenarioFormatter({ title, rawData, setRawData, scenarios, rulemap }: ScenarioFormatterProps) {
+export default function ScenarioFormatter({
+  title,
+  rawData,
+  setRawData,
+  scenarios,
+  rulemap,
+  range,
+}: ScenarioFormatterProps) {
   const [dataSource, setDataSource] = useState<object[]>([]);
   const [columns, setColumns] = useState(COLUMNS);
   const [showTable, setShowTable] = useState(true);
@@ -74,7 +82,8 @@ export default function ScenarioFormatter({ title, rawData, setRawData, scenario
               scenarios,
               updatedRawData,
               setRawData,
-              rulemap?.inputs.find((item) => item.field === field)
+              rulemap?.inputs.find((item) => item.field === field),
+              range
             ),
             key: index,
           };

--- a/app/types/scenario.d.ts
+++ b/app/types/scenario.d.ts
@@ -12,4 +12,5 @@ export interface Variable {
   value: any;
   type?: string;
   field?: string;
+  nested?: string | boolean;
 }


### PR DESCRIPTION
Isolation tester update allows ranges to be entered for number and date fields. 
Linked rules properly filter inputs out from final display, while still displaying missing inputs/outputs in save/publish warning popup.

See https://github.com/bcgov/brm-backend/pull/66