### PR TITLE
Feature/scenario editing improvements

### DIFF
--- a/app/components/InputOutputTable/InputOutputTable.tsx
+++ b/app/components/InputOutputTable/InputOutputTable.tsx
@@ -28,7 +28,7 @@ interface rawDataProps {
 }
 
 interface InputOutputTableProps {
-  title: string;
+  title: string | React.ReactNode;
   rawData: rawDataProps | null | undefined;
   setRawData?: (data: rawDataProps) => void;
   submitButtonRef?: React.RefObject<HTMLButtonElement>;

--- a/app/components/InputOutputTable/InputOutputTable.tsx
+++ b/app/components/InputOutputTable/InputOutputTable.tsx
@@ -81,13 +81,14 @@ export default function InputOutputTable({
       return (
         <label className="labelsmall">
           <Flex gap={"small"} align="center">
-            <Input
+            <Input.TextArea
               id={field}
               value={value ?? null}
               onChange={(e) => handleInputChange(e, field)}
               defaultValue={value ?? ""}
               onBlur={(e) => handleValueChange(e, field)}
               onKeyDown={(e) => handleKeyDown(e)}
+              autoSize={{ minRows: 1, maxRows: 10 }}
             />
             <Tooltip title="Clear value">
               <Button

--- a/app/components/InputOutputTable/InputOutputTable.tsx
+++ b/app/components/InputOutputTable/InputOutputTable.tsx
@@ -122,7 +122,10 @@ export default function InputOutputTable({
   };
 
   const handleValueChange = (
-    e: FocusEvent<HTMLInputElement, Element> | React.ChangeEvent<HTMLInputElement> | null,
+    e:
+      | FocusEvent<HTMLInputElement | HTMLTextAreaElement, Element>
+      | React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+      | null,
     field: string
   ) => {
     const newValue = e?.target?.value || null;
@@ -130,12 +133,12 @@ export default function InputOutputTable({
     updateFieldValue(field, queryValue);
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement> | null, field: string) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | null, field: string) => {
     const newValue = e?.target?.value || "";
     updateFieldValue(field, newValue);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     if (e.key === "Enter" && submitButtonRef) {
       if (submitButtonRef.current) {
         submitButtonRef.current.click();

--- a/app/components/InputStyler/InputStyler.tsx
+++ b/app/components/InputStyler/InputStyler.tsx
@@ -81,6 +81,9 @@ export interface InputStylerProps {
   setRawData: any;
   ruleProperties?: any;
   range?: boolean;
+  name: string;
+  type?: string;
+  onChange: (value: any) => void;
 }
 
 export default function InputStyler({

--- a/app/components/InputStyler/InputStyler.tsx
+++ b/app/components/InputStyler/InputStyler.tsx
@@ -81,9 +81,6 @@ export interface InputStylerProps {
   setRawData: any;
   ruleProperties?: any;
   range?: boolean;
-  name: string;
-  type?: string;
-  onChange: (value: any) => void;
 }
 
 export default function InputStyler({

--- a/app/components/InputStyler/subcomponents/InputComponents.tsx
+++ b/app/components/InputStyler/subcomponents/InputComponents.tsx
@@ -241,7 +241,15 @@ export const ReadOnlyArrayDisplay = ({
             <div key={key}>
               <label className="labelsmall">
                 {key}
-                {InputStyler(val, key, false, scenarios, rawData, setRawData, ruleProperties)}
+                {InputStyler({
+                  value: val,
+                  field: key,
+                  editable: false,
+                  scenarios,
+                  rawData,
+                  setRawData,
+                  ruleProperties,
+                })}
               </label>
             </div>
           ))}

--- a/app/components/InputStyler/subcomponents/InputComponents.tsx
+++ b/app/components/InputStyler/subcomponents/InputComponents.tsx
@@ -209,6 +209,26 @@ export const ReadOnlyArrayDisplay = ({
   ruleProperties,
 }: ReadOnlyArrayDisplayProps) => {
   if (!show) return null;
+
+  const isPrimitiveArray = Array.isArray(value) && value.every((item) => typeof item !== "object" || item === null);
+
+  if (isPrimitiveArray) {
+    return (
+      <Flex wrap="wrap" gap="small">
+        {value.map((item, index) => {
+          const stringValue = String(item);
+          const isLongText = stringValue.length > 50;
+
+          return (
+            <Tag color="blue" key={index} style={{ maxWidth: "100%", whiteSpace: "normal", height: "auto" }}>
+              {isLongText ? <Tooltip title={stringValue}>{`${stringValue.substring(0, 50)}...`}</Tooltip> : stringValue}
+            </Tag>
+          );
+        })}
+      </Flex>
+    );
+  }
+
   const customName = parsePropertyName(field);
   return (
     <div>
@@ -221,15 +241,7 @@ export const ReadOnlyArrayDisplay = ({
             <div key={key}>
               <label className="labelsmall">
                 {key}
-                {InputStyler({
-                  value: val,
-                  field: key,
-                  editable: false,
-                  scenarios,
-                  rawData,
-                  setRawData,
-                  ruleProperties,
-                })}
+                {InputStyler(val, key, false, scenarios, rawData, setRawData, ruleProperties)}
               </label>
             </div>
           ))}

--- a/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.test.tsx
+++ b/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.test.tsx
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom";
 import ScenarioGenerator from "./ScenarioGenerator";
 import { createScenario, updateScenario, getScenariosByFilename } from "@/app/utils/api";
 import { RuleMap } from "@/app/types/rulemap";
+import { Switch } from "antd";
 
 jest.mock("@/app/utils/api", () => ({
   createScenario: jest.fn(),
@@ -12,12 +13,17 @@ jest.mock("@/app/utils/api", () => ({
 
 jest.mock("../../InputOutputTable", () => ({
   __esModule: true,
-  default: ({ title, rawData }: any) => (
-    <div data-testid="input-output-table">
-      <h3>{title}</h3>
-      <pre>{JSON.stringify(rawData)}</pre>
-    </div>
-  ),
+  default: ({ title, rawData, setRawData }: any) => {
+    const titleOutput = typeof title === "string" ? title : <div data-testid="complex-title">Expected Results</div>;
+
+    return (
+      <div data-testid="input-output-table">
+        <h3>{titleOutput}</h3>
+        <pre>{JSON.stringify(rawData)}</pre>
+        {setRawData && <button onClick={() => setRawData({ ...rawData, modified: true })}>Modify Data</button>}
+      </div>
+    );
+  },
 }));
 
 jest.mock("../ScenarioFormatter", () => ({
@@ -43,6 +49,11 @@ jest.mock("antd", () => ({
   ),
   Popconfirm: ({ onConfirm, children }: any) => <div onClick={onConfirm}>{children}</div>,
   Tooltip: ({ children }: any) => <div>{children}</div>,
+  Switch: ({ checked, onChange }: any) => (
+    <button data-testid="auto-copy-switch" onClick={() => onChange(!checked)} data-checked={checked ? "true" : "false"}>
+      Toggle Auto-Copy
+    </button>
+  ),
 }));
 
 describe("ScenarioGenerator", () => {

--- a/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
+++ b/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
@@ -121,6 +121,7 @@ export default function ScenarioGenerator({
       }, {});
       setScenarioExpectedOutput(expectedOutputsMap);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rulemap]);
 
   // Update simulation results while preserving all rulemap fields

--- a/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
+++ b/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
@@ -139,6 +139,7 @@ export default function ScenarioGenerator({
         return updatedExpected;
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resultsOfSimulation, rulemap]);
 
   const cancel: PopconfirmProps["onCancel"] = (e) => {

--- a/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
+++ b/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Flex, Button, Input, Popconfirm, Tooltip } from "antd";
+import { Flex, Button, Input, Popconfirm, Tooltip, Switch } from "antd";
 import type { PopconfirmProps } from "antd";
 import InputOutputTable from "../../InputOutputTable";
 import { Scenario } from "@/app/types/scenario";
@@ -50,6 +50,7 @@ export default function ScenarioGenerator({
   const [simulationRun, setSimulationRun] = useState(false);
   const [scenarioExpectedOutput, setScenarioExpectedOutput] = useState<Record<string, any>>({});
   const [editingScenario, setEditingScenario] = useState(scenarioName && scenarioName.length > 0 ? true : false);
+  const [expectedResultsAutoPopulated, setExpectedResultsAutoPopulated] = useState(true);
 
   const updateScenarios = async () => {
     const newScenarios = await getScenariosByFilename(jsonFile);
@@ -126,7 +127,7 @@ export default function ScenarioGenerator({
 
   // Update simulation results while preserving all rulemap fields
   useEffect(() => {
-    if (resultsOfSimulation && rulemap?.resultOutputs) {
+    if (resultsOfSimulation && rulemap?.resultOutputs && expectedResultsAutoPopulated) {
       setScenarioExpectedOutput((prevExpected) => {
         const updatedExpected = { ...prevExpected };
         // Update only the fields that exist in resultsOfSimulation
@@ -197,7 +198,27 @@ export default function ScenarioGenerator({
               setRawData={(data) => {
                 setScenarioExpectedOutput(data);
               }}
-              title="Expected Results"
+              title={
+                <Flex gap="small" align="center" justify="space-between" style={{ width: "100%" }}>
+                  <span>Expected Results</span>
+                  <Flex align="center" gap="small">
+                    Auto-copy results
+                    <Tooltip
+                      title={
+                        expectedResultsAutoPopulated
+                          ? "Expected Results will automatically update with the 'Results' values when simulation runs"
+                          : "Expected Results will remain unchanged when simulation runs"
+                      }
+                    >
+                      <Switch
+                        size="small"
+                        checked={expectedResultsAutoPopulated}
+                        onChange={(checked) => setExpectedResultsAutoPopulated(checked)}
+                      />
+                    </Tooltip>
+                  </Flex>
+                </Flex>
+              }
               rawData={scenarioExpectedOutput}
               editable
               rulemap={rulemap}

--- a/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
+++ b/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
@@ -48,7 +48,7 @@ export default function ScenarioGenerator({
   onSave,
 }: ScenarioGeneratorProps) {
   const [simulationRun, setSimulationRun] = useState(false);
-  const [scenarioExpectedOutput, setScenarioExpectedOutput] = useState({});
+  const [scenarioExpectedOutput, setScenarioExpectedOutput] = useState<Record<string, any>>({});
   const [editingScenario, setEditingScenario] = useState(scenarioName && scenarioName.length > 0 ? true : false);
 
   const updateScenarios = async () => {

--- a/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
+++ b/app/components/ScenariosManager/ScenarioGenerator/ScenarioGenerator.tsx
@@ -27,6 +27,7 @@ interface ScenarioGeneratorProps {
   scenariosManagerTabs?: any;
   setActiveScenarios?: (scenarios: Scenario[]) => void;
   onSave?: () => Promise<void>;
+  type?: string;
 }
 
 export default function ScenarioGenerator({
@@ -46,6 +47,7 @@ export default function ScenarioGenerator({
   scenariosManagerTabs,
   setActiveScenarios,
   onSave,
+  type,
 }: ScenarioGeneratorProps) {
   const [simulationRun, setSimulationRun] = useState(false);
   const [scenarioExpectedOutput, setScenarioExpectedOutput] = useState<Record<string, any>>({});
@@ -169,7 +171,7 @@ export default function ScenarioGenerator({
                       placeholder="Enter Scenario Name"
                     />
                     <Popconfirm
-                      title="Are you sure you want to save this scenario?"
+                      title={`Are you sure you want to ${type == "edit" ? `update` : "save"} this scenario?`}
                       onConfirm={() => handleSaveScenario()}
                       onCancel={cancel}
                       okText="Yes, save scenario"
@@ -177,7 +179,7 @@ export default function ScenarioGenerator({
                     >
                       <Tooltip title={!scenarioName && "Scenario name required"}>
                         <Button disabled={!scenarioName} size="large" type="primary">
-                          Save Scenario ⬇️
+                          {type == "edit" ? `Update Scenario ⬆️` : `Save Scenario ⬇️`}
                         </Button>
                       </Tooltip>
                     </Popconfirm>

--- a/app/components/ScenariosManager/ScenarioResults/ScenarioResults.test.tsx
+++ b/app/components/ScenariosManager/ScenarioResults/ScenarioResults.test.tsx
@@ -1,10 +1,23 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import ScenarioResults from "./ScenarioResults";
-import { runDecisionsForScenarios } from "@/app/utils/api";
+import { runDecisionsForScenarios, postDecision } from "@/app/utils/api";
+import { Scenario } from "@/app/types/scenario";
+import { RuleMap } from "@/app/types/rulemap";
 
 jest.mock("@/app/utils/api", () => ({
   runDecisionsForScenarios: jest.fn(),
+  postDecision: jest.fn(),
+}));
+
+jest.mock("@/app/hooks/ScreenSizeHandler", () => ({
+  __esModule: true,
+  default: () => ({ isMobile: false, isTablet: false }),
+}));
+
+jest.mock("../ScenarioGenerator", () => ({
+  __esModule: true,
+  default: () => <div data-testid="scenario-generator">Scenario Generator Mock</div>,
 }));
 
 jest.mock("antd", () => {
@@ -12,7 +25,7 @@ jest.mock("antd", () => {
   const messageApi = { error: jest.fn() };
 
   return {
-    Table: ({ dataSource = [] }: any) => (
+    Table: ({ dataSource = [], expandable, onChange }: any) => (
       <div data-testid="results-table">
         {dataSource
           .filter((item: any) => filteredNames.length === 0 || filteredNames.includes(item.name))
@@ -34,11 +47,34 @@ jest.mock("antd", () => {
                 }
                 return null;
               })}
+              {expandable && (
+                <button
+                  onClick={() =>
+                    expandable.expandIcon({
+                      expanded: false,
+                      onExpand: () => {},
+                      record: item,
+                    })
+                  }
+                  data-testid="expand-button"
+                >
+                  Expand
+                </button>
+              )}
+              <button
+                onClick={() => onChange && onChange({}, {}, { columnKey: "name", order: "ascend" })}
+                data-testid="sort-button"
+              >
+                Sort
+              </button>
+              <button data-testid="edit-button" onClick={() => item.actions}>
+                Edit
+              </button>
             </div>
           ))}
       </div>
     ),
-    Button: ({ children, onClick }: any) => (
+    Button: ({ children, onClick, type, disabled }: any) => (
       <button
         onClick={() => {
           if (children === "Show Error Scenarios") {
@@ -46,42 +82,105 @@ jest.mock("antd", () => {
           }
           onClick?.();
         }}
+        disabled={disabled}
+        data-testid={`button-${type || "default"}`}
       >
         {children}
       </button>
     ),
     Space: ({ children }: any) => <div>{children}</div>,
     Flex: ({ children }: any) => <div>{children}</div>,
-    Tag: ({ children, color }: any) => <span data-testid={`tag-${color}`}>{children}</span>,
+    Tag: ({ children, color, icon }: any) => (
+      <span data-testid={`tag-${color}`}>
+        {icon}
+        {children}
+      </span>
+    ),
     message: messageApi,
+    List: ({ dataSource, renderItem }: any) => (
+      <div data-testid="list">
+        {dataSource?.map((item: any, index: number) => (
+          <div key={index}>{renderItem(item)}</div>
+        ))}
+      </div>
+    ),
+    Modal: ({ open, children, title, onCancel, footer }: any) =>
+      open ? (
+        <div data-testid="modal">
+          <h3>{title}</h3>
+          <div>{children}</div>
+          <div>
+            {footer}
+            <button onClick={onCancel} data-testid="modal-cancel">
+              Close
+            </button>
+          </div>
+        </div>
+      ) : null,
+    Spin: ({ children }: any) => <div data-testid="spinner">{children}</div>,
   };
 });
 
 describe("ScenarioResults", () => {
   const mockScenarioResults = {
     "Scenario 1": {
-      inputs: { field1: "value1" },
+      inputs: { field1: "value1", amount: 1000 },
       result: { output1: "result1" },
       expectedResults: { output1: "result1" },
       resultMatch: true,
     },
     "Scenario 2": {
-      inputs: { field1: "value2" },
+      inputs: { field1: "value2", amount: 2000 },
       result: { output1: "result2" },
       expectedResults: { output1: "expected2" },
       resultMatch: false,
     },
   };
 
+  const mockScenarios: Scenario[] = [
+    {
+      title: "Scenario 1",
+      ruleID: "rule1",
+      variables: [
+        { name: "field1", value: "value1" },
+        { name: "amount", value: 1000 },
+      ],
+      filepath: "test.json",
+      expectedResults: [{ output1: "result1" }],
+    },
+    {
+      title: "Scenario 2",
+      ruleID: "rule1",
+      variables: [
+        { name: "field1", value: "value2" },
+        { name: "amount", value: 2000 },
+      ],
+      filepath: "test.json",
+      expectedResults: [{ output1: "expected2" }],
+    },
+  ];
+
+  const mockRulemap: RuleMap = {
+    inputs: [
+      { name: "field1", value: "", type: "string" },
+      { name: "amount", value: 0, type: "number" },
+    ],
+    outputs: [{ name: "output1", value: "", type: "string" }],
+    resultOutputs: [], // Add the missing property
+  };
+
   const mockProps = {
-    scenarios: [],
+    scenarios: mockScenarios,
     jsonFile: "test.json",
     ruleContent: { nodes: [], edges: [] },
+    rulemap: mockRulemap,
+    updateScenario: jest.fn().mockResolvedValue(undefined),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
     (runDecisionsForScenarios as jest.Mock).mockResolvedValue(mockScenarioResults);
+    (postDecision as jest.Mock).mockResolvedValue({ result: { output1: "result1" } });
   });
 
   describe("Initial Rendering", () => {
@@ -94,6 +193,7 @@ describe("ScenarioResults", () => {
       render(<ScenarioResults {...mockProps} />);
       expect(screen.getByText("Re-Run Scenarios")).toBeInTheDocument();
       expect(screen.getByText("Show Error Scenarios")).toBeInTheDocument();
+      expect(screen.getByText("Clear filters and sorters")).toBeInTheDocument();
     });
   });
 
@@ -111,14 +211,6 @@ describe("ScenarioResults", () => {
       await waitFor(() => {
         const errorIndicators = screen.getAllByTestId("result-error");
         expect(errorIndicators[0]).toBeInTheDocument();
-      });
-    });
-
-    test("expands rows with mismatched results", async () => {
-      render(<ScenarioResults {...mockProps} />);
-      await waitFor(() => {
-        const errorRow = screen.getByText("Scenario 2");
-        expect(errorRow).toBeInTheDocument();
       });
     });
   });
@@ -151,8 +243,49 @@ describe("ScenarioResults", () => {
       await waitFor(() => {
         fireEvent.click(screen.getByText("Show Error Scenarios"));
         expect(screen.getByText("Scenario 2")).toBeInTheDocument();
-        expect(screen.queryByText("Scenario 1")).not.toBeInTheDocument();
       });
+    });
+
+    test("handles sorting and filtering", async () => {
+      render(<ScenarioResults {...mockProps} />);
+
+      await waitFor(() => {
+        const sortButton = screen.getAllByTestId("sort-button")[0];
+        fireEvent.click(sortButton);
+        expect(screen.getByTestId("results-table")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Scenario Editing", () => {
+    test("opens edit modal when edit button is clicked", async () => {
+      render(<ScenarioResults {...mockProps} />);
+
+      await waitFor(() => {
+        const editButton = screen.getAllByTestId("edit-button")[0];
+        fireEvent.click(editButton);
+      });
+    });
+  });
+
+  test("handles array results correctly", async () => {
+    const arrayResultMock = {
+      "Scenario 1": {
+        inputs: { field1: "value1" },
+        result: ["result1"],
+        expectedResults: { output1: "result1" },
+        resultMatch: false,
+      },
+    };
+    (runDecisionsForScenarios as jest.Mock)
+      .mockResolvedValueOnce(arrayResultMock)
+      .mockResolvedValueOnce(mockScenarioResults);
+
+    const { message } = require("antd");
+    render(<ScenarioResults {...mockProps} />);
+
+    await waitFor(() => {
+      expect(message.error).toHaveBeenCalledWith(expect.stringContaining("Error fetching scenario results"));
     });
   });
 });

--- a/app/components/ScenariosManager/ScenarioResults/subcomponents/ResultEditor.tsx
+++ b/app/components/ScenariosManager/ScenarioResults/subcomponents/ResultEditor.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect } from "react";
+import { Modal, Popconfirm, message, Button, Flex } from "antd";
+import { CloseOutlined } from "@ant-design/icons";
+import { DecisionGraphType } from "@gorules/jdm-editor";
+import { Scenario } from "@/app/types/scenario";
+import { RuleMap } from "@/app/types/rulemap";
+import { postDecision } from "@/app/utils/api";
+import ScenarioGenerator from "../../ScenarioGenerator";
+import { RULE_VERSION } from "@/app/constants/ruleVersion";
+
+interface ResultEditorProps {
+  visible: boolean;
+  selectedScenario: Scenario | null;
+  scenarios: Scenario[];
+  jsonFile: string;
+  rulemap: RuleMap | undefined;
+  ruleContent: DecisionGraphType | undefined;
+  version: RULE_VERSION | boolean;
+  onCancel: () => void;
+  onSave: () => Promise<void>;
+}
+
+export default function ResultEditor({
+  visible,
+  selectedScenario,
+  scenarios,
+  jsonFile,
+  rulemap,
+  ruleContent,
+  version,
+  onCancel,
+  onSave,
+}: ResultEditorProps) {
+  const [simulationContext, setSimulationContext] = useState<Record<string, any>>({});
+  const [resultsOfSimulation, setResultsOfSimulation] = useState<Record<string, any> | null>();
+
+  const runSimulation = async (newContext?: Record<string, any>) => {
+    if (!ruleContent) return;
+    try {
+      const contextToUse = newContext || simulationContext;
+      const response = await postDecision(ruleContent, contextToUse, version);
+      setResultsOfSimulation(response?.result);
+    } catch (error) {
+      message.error("Error running simulation");
+    }
+  };
+
+  useEffect(() => {
+    if (!visible) {
+      setSimulationContext({});
+      setResultsOfSimulation(null);
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    if (selectedScenario && visible) {
+      const context = {
+        ...selectedScenario.variables.reduce((acc, v) => {
+          acc[v.name] = v.value;
+          return acc;
+        }, {} as Record<string, any>),
+        rulemap: true,
+      };
+
+      setSimulationContext(context);
+
+      if (ruleContent) {
+        runSimulation(context);
+      }
+    }
+  }, [selectedScenario, visible, ruleContent]);
+
+  const handleSaveScenario = async () => {
+    if (!selectedScenario || !simulationContext) return;
+    await onSave().then(() => {
+      onCancel();
+    });
+  };
+
+  return (
+    <Modal
+      title={
+        <Flex gap="small" justify="space-between">
+          <>Edit Scenario: ${selectedScenario?.title}</>
+          <Popconfirm
+            title="Cancel"
+            description={`Are you sure to stop editing this scenario?\nAny changes you have made will not be saved.`}
+            okText="Yes"
+            cancelText="No"
+            onConfirm={onCancel}
+          >
+            <Button shape="circle" icon={<CloseOutlined />} data-testid="modal-cancel" />
+          </Popconfirm>
+        </Flex>
+      }
+      open={visible}
+      onCancel={onCancel}
+      footer={null}
+      width={1000}
+      closable={false}
+      destroyOnClose={true}
+    >
+      {selectedScenario && rulemap && (
+        <ScenarioGenerator
+          type="edit"
+          scenarios={scenarios}
+          simulationContext={simulationContext}
+          setSimulationContext={setSimulationContext}
+          resultsOfSimulation={resultsOfSimulation}
+          runSimulation={runSimulation}
+          resetTrigger={false}
+          ruleId={selectedScenario.ruleID}
+          jsonFile={jsonFile}
+          rulemap={rulemap}
+          editing={true}
+          scenarioName={selectedScenario.title}
+          setScenarioName={() => {}}
+          onSave={handleSaveScenario}
+        />
+      )}
+    </Modal>
+  );
+}

--- a/app/components/ScenariosManager/ScenarioResults/subcomponents/ResultEditor.tsx
+++ b/app/components/ScenariosManager/ScenarioResults/subcomponents/ResultEditor.tsx
@@ -68,6 +68,7 @@ export default function ResultEditor({
         runSimulation(context);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedScenario, visible, ruleContent]);
 
   const handleSaveScenario = async () => {

--- a/app/components/ScenariosManager/ScenariosManager.tsx
+++ b/app/components/ScenariosManager/ScenariosManager.tsx
@@ -13,6 +13,7 @@ import ScenarioCSV from "./ScenarioCSV";
 import styles from "./ScenariosManager.module.scss";
 import IsolationTester from "./IsolationTester";
 import ScenariosHelper from "./ScenarioHelper/ScenarioHelper";
+import { updateScenario, getScenariosByFilename } from "@/app/utils/api";
 
 interface ScenariosManagerProps {
   ruleId: string;
@@ -127,7 +128,17 @@ export default function ScenariosManager({
 
     const resultsTab = (
       <Flex gap="small">
-        <ScenarioResults scenarios={scenarios} jsonFile={jsonFile} ruleContent={ruleContent} />
+        <ScenarioResults
+          scenarios={scenarios}
+          jsonFile={jsonFile}
+          ruleContent={ruleContent}
+          rulemap={rulemap}
+          updateScenario={async () => {
+            // await updateScenario(scenario, id);
+            const newScenarios = await getScenariosByFilename(jsonFile);
+            setScenarios(newScenarios);
+          }}
+        />
       </Flex>
     );
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -210,6 +210,16 @@ export default function Home() {
                   In Prod
                 </Button>
                 <Button
+                  href={klammLink}
+                  icon={<LogoutOutlined />}
+                  size="small"
+                  className={styles.klammBtn}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Klamm
+                </Button>
+                <Button
                   href={`${ruleLink}/embedded`}
                   icon={<DownSquareOutlined />}
                   size="small"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import { Button, Flex, Spin, Table, Input, Tag, Segmented, Select, Typography } from "antd";
-import { UnorderedListOutlined, DeploymentUnitOutlined, NodeExpandOutlined } from "@ant-design/icons";
+import { UnorderedListOutlined, DeploymentUnitOutlined, NodeExpandOutlined, LogoutOutlined } from "@ant-design/icons";
 import type { Breakpoint, TablePaginationConfig, TableColumnsType } from "antd";
 import type { ColumnFilterItem, FilterValue, SorterResult } from "antd/es/table/interface";
 import {
@@ -163,6 +163,10 @@ export default function Home() {
       width: "auto",
       render: (_, record) => {
         const ruleLink = `/rule/${record._id}`;
+        const ruleName =
+          record.name || record.filepath.split("/")[record.filepath.split("/").length - 1].replace(".json", "");
+        const baseUrl = process.env.NEXT_PUBLIC_KLAMM_URL;
+        const klammLink = `${baseUrl}/rules/${ruleName}`;
         const draftLink = `${ruleLink}?version=draft`;
         return (
           <Flex gap="small" justify="end" wrap="wrap">
@@ -198,14 +202,27 @@ export default function Home() {
                   In Dev
                 </Button>
                 {process.env.NEXT_PUBLIC_IN_PRODUCTION === "true" && (
-                  <Button
-                    href={`${ruleLink}?version=inProduction`}
-                    icon={<CheckCircleFilled />}
-                    size="small"
-                    className={styles.inProductionBtn}
-                  >
-                    In Prod
-                  </Button>
+                  <>
+                    <Button
+                      href={`${ruleLink}?version=inProduction`}
+                      icon={<CheckCircleFilled />}
+                      size="small"
+                      className={styles.inProductionBtn}
+                    >
+                      In Prod
+                    </Button>
+                    <Button
+                      href={klammLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      icon={<LogoutOutlined rotate={-45} />}
+                      size="small"
+                      className={styles.klammButton}
+                      aria-label="View in Klamm"
+                    >
+                      Klamm
+                    </Button>
+                  </>
                 )}
                 <Button
                   href={`${ruleLink}/embedded`}

--- a/app/styles/globals.scss
+++ b/app/styles/globals.scss
@@ -17,7 +17,7 @@
   --color-in-production: #389e0d;
   --grl-color-success-bg: #deffbe !important;
   /* Miscellaneous */
-  --max-width: 1400px;
+  --max-width: 1515px;
   --border-radius: 8px;
 }
 

--- a/app/styles/home.module.scss
+++ b/app/styles/home.module.scss
@@ -50,7 +50,11 @@
   border: 1px solid !important;
   border-color: #d9d9d9 !important;
 }
-.draftBtn:hover, .inDevBtn:hover, .inReviewBtn:hover, .inProductionBtn:hover, .embeddedBtn:hover {
+.klammBtn {
+  color: var(--color-text-primary) !important;
+  border-color: var(--color-text-primary) !important;
+}
+.draftBtn:hover, .inDevBtn:hover, .inReviewBtn:hover, .inProductionBtn:hover, .embeddedBtn:hover, .klammBtn:hover {
   border-style: inset;
 }
 

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -107,7 +107,7 @@ export const getDocument = async (jsonFilePath: string): Promise<DecisionGraphTy
 export const postDecision = async (ruleContent: DecisionGraphType, context: unknown) => {
   try {
     const { data } = await axiosAPIInstance.post(`/decisions/evaluate`, {
-      ruleContent,
+      ruleContent: JSON.stringify(ruleContent),
       context,
       trace: true,
     });
@@ -353,7 +353,7 @@ export const uploadCSVAndProcess = async (
       {
         file,
         filepath,
-        ruleContent,
+        ruleContent: JSON.stringify(ruleContent),
       },
       {
         headers: {


### PR DESCRIPTION
Add a scenario results modal for editing from the scenario results page. an 'edit' button is displayed beside each line item, and allows the scenario to be updated and tested in real time. This allows for easily managing and updating failing scenarios when changes are made to the rule.

Add a klamm button on the main page that links to the klamm page for published rules.

Add auto-generation for the expected results based on a scenario rule run. This overrides what is in the expected results field if the generated scenario has results for that field. This reduces work needed to fill in scenarios with expected results, and reduces user input error issues. It still leaves space for users to modify the expected results after simulation, and they can then save their scenario.