### PR TITLE
Fix to return functionality of 'today' as an allowed date in date validation

### DIFF
--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -65,8 +65,8 @@ export const getFieldValidation = (validationCriteria: string, validationType: s
     validationRules["type"] = "true-false";
     return validationRules;
   }
-  const parseValue = (value: string): Date | number | dayjs.Dayjs => {
-    if (value === "today") return new Date();
+  const parseValue = (value: string): number | dayjs.Dayjs => {
+    if (value === "today") return dayjs(new Date());
     return dataType === "number-input" ? Number(value) : dayjs(value);
   };
 


### PR DESCRIPTION
Compatibility issue of Date instead of dayjs was causing 'today' to break functionality for date pickers when used.